### PR TITLE
feat: structure detection + dropdown option tracking

### DIFF
--- a/core/tree.py
+++ b/core/tree.py
@@ -182,7 +182,7 @@ def filter_useful_elements(elements: List[Dict], chrome_y: int = None) -> List[D
         if name and role in ACTIONABLE_ROLES:
             return True
         if role in NOISE_ROLES:
-            # Only filter unnamed noise elements - named ones may be
+            # Only filter unnamed noise elements — named ones may be
             # actual content (e.g. Perplexity knowledge tiles, artifact panels)
             return bool(name)
         return bool(name)
@@ -278,13 +278,13 @@ def find_menu_items(firefox, platform_doc=None) -> List[Dict]:
                     return
 
                 # Match menu containers: menu, listbox, popup menu, panel
-                # NOTE: 'list' excluded - matches sidebar History on Gemini/ChatGPT,
+                # NOTE: 'list' excluded — matches sidebar History on Gemini/ChatGPT,
                 # preventing dropdown detection. Real dropdowns use menu/listbox/popup.
                 _MENU_CONTAINERS = {'menu', 'listbox', 'popup menu', 'panel'}
                 if role in _MENU_CONTAINERS:
                     # Check SHOWING state unless relaxed (retry mode)
                     if require_showing and not _is_menu_showing(obj):
-                        # Still recurse children - container might be nested
+                        # Still recurse children — container might be nested
                         pass
                     else:
                         items = []
@@ -386,8 +386,9 @@ def compute_structure_hash(elements: List[Dict], screen_height: int = 1080,
     new controls appear, layout shifts) while being stable across
     normal content changes (new messages, different text).
 
-    Sidebar content (list items with 'link' role in the left 20% of
-    screen) is excluded since sidebar sessions change constantly.
+    Content-variable roles (links, list items, headings, static text)
+    are excluded entirely — these change with conversation history and
+    sidebar state, not UI structure.
 
     Args:
         elements: Element list from find_elements or filter_useful_elements.
@@ -399,22 +400,18 @@ def compute_structure_hash(elements: List[Dict], screen_height: int = 1080,
     """
     band_height = max(screen_height // grid_rows, 1)
 
-    # Collect role+band pairs, excluding sidebar session links
-    # Sidebar is typically in the left ~20% of screen (< 300px on 1920w)
+    # Roles that represent content, not UI structure — these change with
+    # conversation history, sidebar sessions, and page content
+    _CONTENT_ROLES = {'link', 'list item', 'heading', 'static', 'label',
+                      'paragraph', 'text', 'section'}
+
     structure_pairs = []
     for e in elements:
         role = e.get('role', '')
-        if not role:
+        if not role or role in _CONTENT_ROLES:
             continue
 
-        x = e.get('x', 0)
         y = e.get('y', 0)
-
-        # Skip sidebar content: links/list items in the left gutter
-        # These are session history items that change constantly
-        if x < 300 and role in ('link', 'list item', 'heading'):
-            continue
-
         band = y // band_height
         structure_pairs.append(f"{role}@{band}")
 

--- a/tools/dropdown.py
+++ b/tools/dropdown.py
@@ -8,7 +8,7 @@ Dropdown option tracking:
 - When a dropdown is opened, compares found items against YAML capabilities
 - Flags new items (in dropdown but not in YAML) and missing items
   (in YAML but not in dropdown)
-- Gemini decides what the changes mean - no thresholds, no special cases
+- Claude decides what the changes mean - no thresholds, no special cases
 """
 
 import json

--- a/tools/inspect.py
+++ b/tools/inspect.py
@@ -97,8 +97,9 @@ def _check_structure_change(platform: str, elements: list,
 
     stored = redis_client.get(fingerprint_key)
 
-    # Always update the stored fingerprint (24h TTL)
-    redis_client.setex(fingerprint_key, 86400, current_hash)
+    # Always update the stored fingerprint (no expiry — baseline persists
+    # across sessions so UI redesigns are detected even after downtime)
+    redis_client.set(fingerprint_key, current_hash)
 
     if stored is None:
         # First time seeing this platform - baseline stored, no comparison
@@ -133,8 +134,8 @@ def handle_inspect(platform: str, redis_client, scroll: str = "bottom", **kwargs
     2. Otherwise: just switch to platform tab (stateless mode)
     3. Scroll according to `scroll` parameter, scan AT-SPI tree
     4. Find all elements, filter to useful ones
-    5. Store in Redis
-    6. Check for structure changes (layout fingerprinting)
+    5. Check for structure changes (layout fingerprinting)
+    6. Store in Redis
 
     Args:
         platform: Which platform to inspect.


### PR DESCRIPTION
## Summary
- **Structure hash fingerprinting**: `compute_structure_hash()` captures UI layout (roles + Y-grid bands) without content. Detects platform UI redesigns while staying stable across normal chat usage.
- **Inspect structure change detection**: Each `taey_inspect` compares layout fingerprint against Redis baseline, flags `structure_changed: true` when platform UI shifts.
- **Dropdown option tracking**: `taey_select_dropdown` compares found items against YAML capabilities, flags new/missing items so Claude knows when platforms add or remove options.

Origin: Perplexity contribution with Spark review fixes.

## Review fixes applied
- "Gemini" -> "Claude" misspeak in docstring
- Replaced coordinate-based sidebar exclusion (x < 300px) with role-based filtering — works regardless of sidebar open/closed state
- Removed 24h TTL on structure fingerprint — baseline persists so UI redesigns are detected even after downtime
- Fixed docstring step order to match code
- Restored em-dash style consistency

## Test plan
- [ ] Verify `taey_inspect` returns `structure_change` field on first UI change
- [ ] Verify `taey_select_dropdown` returns `capability_changes` when dropdown items differ from YAML
- [ ] Verify structure hash is stable across consecutive inspects with new messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)