### PR TITLE
feat: branch protection, CONTRIBUTING.md, PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## What does this PR do?
+
+<!-- One or two sentences describing the change -->
+
+## Why?
+
+<!-- What problem does it solve, or what behaviour does it add? -->
+
+## How to test
+
+<!-- Steps to verify the change works -->
+
+## Related issues
+
+<!-- Link any relevant issues: Closes #123 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to taeys-hands
+
+## Branch rules
+
+**`main` is protected.** You cannot push directly to it — all changes must go through a pull request with at least one review.
+
+## Workflow
+
+```bash
+# 1. Create a branch for your work
+git checkout -b fix/describe-the-fix      # for bug fixes
+git checkout -b feat/describe-the-feature # for new features
+
+# 2. Make your changes and commit them
+git add <files>
+git commit -m "fix: short description of what and why"
+
+# 3. Push your branch
+git push origin fix/describe-the-fix
+
+# 4. Open a pull request on GitHub
+gh pr create --base main
+```
+
+## Commit message format
+
+```
+type: short description
+
+Longer explanation if needed.
+```
+
+Types: `fix`, `feat`, `refactor`, `docs`, `test`
+
+## Pull request checklist
+
+- Branch is up to date with `main`
+- Code tested manually (run `python3 server.py` and verify with Claude Code MCP)
+- PR description explains what changed and why
+- No private IPs, credentials, or personal config committed
+
+## Platform-specific test environment
+
+You need:
+- Linux with X11
+- Firefox with accessibility enabled (`about:config` → `accessibility.force_disabled` = `0`)
+- Python 3.10+ with `gi.repository` (PyGObject / AT-SPI2)
+- `xdotool`, `xsel`, `xdpyinfo`
+- Optional: Redis, Neo4j for full pipeline testing
+
+See `CLAUDE.md` for the full operational guide.
+
+## Questions
+
+Open an issue — we're happy to help.


### PR DESCRIPTION
## What does this PR do?

Sets up proper contributor workflow for the public repo.

## Why?

`main` was unprotected — anyone with write access could push directly. As a public repo accepting contributions, we need PRs + reviews as the gate.

## Changes

- **GitHub branch protection on `main`**: PRs required, 1 approval needed, stale reviews dismissed, no force push, no direct deletion
- **CONTRIBUTING.md**: explains branch/PR workflow in plain language, commit format, test environment setup
- **`.github/PULL_REQUEST_TEMPLATE.md`**: standard PR description structure for all contributors

## How to test

Try pushing directly to `main` — it should be rejected.