### PR TITLE
fix: remove internal cluster info from public repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,8 @@ REDIS_PORT=6379
 # Used for: conversation history graph (sessions + messages)
 NEO4J_URI=bolt://localhost:7687
 
-# HMM store endpoint (optional)
-HMM_STORE_URL=http://localhost:8095/hmm/store-response
+# Optional webhook — called after each response extraction for custom post-processing
+# HMM_STORE_URL=http://localhost:8095/hmm/store-response
 
 # Instance identifier for Redis key scoping
 # Auto-detected from: TAEY_NODE_ID > tmux session name > hostname

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Services are configured via environment variables with localhost defaults:
 | `REDIS_HOST` | `127.0.0.1` | Redis server host |
 | `REDIS_PORT` | `6379` | Redis server port |
 | `NEO4J_URI` | `bolt://localhost:7687` | Neo4j connection URI |
-| `HMM_STORE_URL` | `http://localhost:8095/hmm/store-response` | HMM store endpoint |
+| `HMM_STORE_URL` | `http://localhost:8095/hmm/store-response` | Optional webhook for custom response post-processing |
 | `TAEY_NODE_ID` | (auto-detected) | Instance identifier for Redis key scoping |
 
 Redis and Neo4j are **optional** — the server starts and operates without them. Session persistence and background monitor notifications require Redis. Conversation history storage requires Neo4j.
@@ -350,53 +350,32 @@ python3 server.py                            # MCP server for that instance
 
 `scripts/tmux-send` is the **only** sanctioned way for Claude instances to communicate with each other. It is critical infrastructure — every node must have it installed.
 
+See `scripts/README.md` for full documentation and the multi-Claude coordination pattern.
+
 ### Install
 
 ```bash
 bash scripts/install-node.sh   # installs tmux-send + system deps on current node
 ```
 
-Or manually:
-```bash
-sudo install -m 755 scripts/tmux-send /usr/local/bin/tmux-send
-```
-
 ### Usage
 
 ```bash
-# Local (2-arg): send to a session on the same machine
+# Local — send to a session on this machine
 tmux-send <session> "message"
 
-# Remote (3-arg): send to a session on another node via SSH
+# Remote — send to a session on another machine via SSH
 tmux-send <host> <session> "message"
-```
-
-Examples:
-```bash
-tmux-send taeys-hands "Resume HMM enrichment"                         # local
-tmux-send jetson jetson-claude "Fix deployed. Run: git pull"          # remote
-tmux-send thor thor-claude "ESCALATION from spark: DB is down"        # remote
 ```
 
 ### Rules (NEVER violate)
 
 | Rule | Why |
 |------|-----|
-| **ALWAYS use `tmux-send`** for Claude-to-Claude messages | Ensures base64 encoding, session verification, audit trail |
+| **ALWAYS use `tmux-send`** for Claude-to-Claude messages | Base64 encoding, session verification, fail-loud |
 | **NEVER use raw SSH** to send messages | Shell expansion corrupts special chars; no verification |
 | **NEVER target human-operated sessions** | Messages arrive as user input — only target Claude Code instances |
-| **Target session must exist** | Script verifies before sending; fail loudly if missing |
-
-### Node Registry
-
-| Node | Hostname | Default Session | Install Path |
-|------|----------|-----------------|--------------|
-| Spark 1 | spark-78c6 | `taeys-hands` | `/home/spark/bin/tmux-send` → `/usr/local/bin/tmux-send` |
-| Jetson | jetson | `jetson-claude` | `/usr/local/bin/tmux-send` |
-| Thor | thor | `thor-claude` | `/usr/local/bin/tmux-send` |
-| Spark 3 (PALIOS) | spark-e4b2 | `claw` | `/usr/local/bin/tmux-send` |
-
-**New nodes**: run `bash scripts/install-node.sh` after cloning the repo.
+| **Target session must exist** | Script exits with error if session not found |
 
 ---
 

--- a/core/tree.py
+++ b/core/tree.py
@@ -359,7 +359,7 @@ def compute_tree_hash(elements: List[Dict]) -> str:
     """Compute SHA256 hash of element role:name pairs for state comparison.
 
     Used to detect whether an action actually changed the UI.
-    Same algorithm as taey-ed-v7's compute_tree_hash for consistency.
+    Stable algorithm — do not change without updating all callers.
 
     Args:
         elements: Element list from find_elements.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,107 @@
+# scripts/
+
+Utility scripts for taeys-hands node setup and Claude-to-Claude communication.
+
+---
+
+## tmux-send
+
+Send a message to a tmux session — locally or on a remote machine over SSH.
+
+This is the backbone of multi-Claude coordination: when you have multiple
+Claude Code instances running (on the same machine or across different nodes),
+`tmux-send` lets them pass instructions to each other reliably.
+
+### Why not just use SSH directly?
+
+Raw SSH + tmux send-keys drops special characters, fails silently on missing
+sessions, and has no feedback. `tmux-send` handles all of that:
+
+- **Base64 encodes** the message — survives shell expansion, quotes, newlines
+- **Verifies** the target session exists before sending
+- **Warns** if the target pane isn't running `claude`
+- **Works locally** (2 args) or **remotely** (3 args, same interface)
+
+### Install
+
+```bash
+# On any node — installs tmux-send + system dependencies
+bash scripts/install-node.sh
+
+# Or manually
+sudo install -m 755 scripts/tmux-send /usr/local/bin/tmux-send
+```
+
+### Usage
+
+```bash
+# Local — send to a tmux session on this machine
+tmux-send <session-name> "your message"
+
+# Remote — send to a tmux session on another machine via SSH
+tmux-send <hostname-or-ip> <session-name> "your message"
+```
+
+### Examples
+
+```bash
+# Wake up a Claude instance in another window
+tmux-send claude-worker "Resume the task from where you left off"
+
+# Send from Spark to a remote worker node
+tmux-send 192.168.1.20 worker-claude "Fix deployed. Run: cd ~/taeys-hands && git pull"
+
+# Escalate a problem to a supervisor Claude
+tmux-send supervisor "ESCALATION from worker: Neo4j connection failed, cannot continue"
+
+# Send a multi-word message (all args after session are joined)
+tmux-send my-session this entire sentence is the message
+```
+
+### Multi-Claude pattern
+
+The typical setup for multi-node taeys-hands operation:
+
+```
+[Coordinator node]          [Worker node 1]         [Worker node 2]
+  tmux: supervisor            tmux: worker-1          tmux: worker-2
+  Claude Code (orchestrates)  Claude Code (executes)  Claude Code (executes)
+
+Coordinator → worker:  tmux-send worker-host worker-1 "Next task: process batch 4"
+Worker → coordinator:  tmux-send coord-host supervisor "DONE: batch 4 complete"
+Worker → coordinator:  tmux-send coord-host supervisor "ESCALATION: attach failed, need fix"
+```
+
+The coordinator (supervisor) handles code changes and decisions.
+Workers execute tasks and escalate when blocked.
+
+### SSH requirements
+
+Remote use requires passwordless SSH access to the target machine.
+The target user's `tmux` must be running with the named session active.
+
+```bash
+# Check if target is reachable and session exists
+ssh <host> "tmux ls"
+```
+
+### Rules
+
+- **Only target Claude Code sessions** — messages arrive as user input, so
+  sending to a human's terminal is disruptive and wrong
+- **Use tmux-send for all Claude-to-Claude messages** — never raw SSH
+- **Sessions must exist** — script exits with error if session not found
+
+---
+
+## install-node.sh
+
+One-command setup for a new taeys-hands node.
+
+```bash
+bash scripts/install-node.sh
+```
+
+Installs:
+- `tmux-send` → `/usr/local/bin/tmux-send`
+- System packages: `xdotool`, `xsel`, `x11-utils` (required for AT-SPI tools)

--- a/scripts/build_consultation.py
+++ b/scripts/build_consultation.py
@@ -16,11 +16,16 @@ Usage:
     python3 build_consultation.py \\
         --type architecture_reasoning \\
         --codebase /path/to/file1.py /path/to/file2.py \\
-        --benchmarks /var/spark/isma/benchmark_option_e.json \\
+        --benchmarks /path/to/benchmark.json \\
         --questions /tmp/questions.md \\
         --output /tmp/family_consultation.md
 
 The output file is ready to attach and send to all 5 platforms.
+
+Environment variables:
+    WEAVIATE_URL        Weaviate GraphQL endpoint (default: http://localhost:8088/v1/graphql)
+    STATE_OF_CONVERGENCE_PATH  Path to STATE_OF_CONVERGENCE.md (default: ~/Downloads/STATE_OF_CONVERGENCE.md)
+    MOTIFS_SOURCE_PATH  Path to motif_reference.py containing MOTIF_REFERENCE constant (default: ~/motifs/motif_reference.py)
 """
 
 import argparse
@@ -32,9 +37,12 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-WEAVIATE_URL = "http://192.168.100.10:8088/v1/graphql"
-STATE_OF_CONVERGENCE = Path.home() / "Downloads/STATE_OF_CONVERGENCE.md"
-MOTIFS_SOURCE = Path.home() / "embedding-server/isma/scripts/hmm_prompts.py"
+WEAVIATE_URL = os.environ.get("WEAVIATE_URL", "http://localhost:8088/v1/graphql")
+WEAVIATE_CLASS = os.environ.get("WEAVIATE_CLASS", "Document")
+STATE_OF_CONVERGENCE = Path(os.environ.get("STATE_OF_CONVERGENCE_PATH",
+                            str(Path.home() / "Downloads/STATE_OF_CONVERGENCE.md")))
+MOTIFS_SOURCE = Path(os.environ.get("MOTIFS_SOURCE_PATH",
+                     str(Path.home() / "motifs/motif_reference.py")))
 
 # Corpus paths in Weaviate source_file fields
 CORPUS_PATHS = {
@@ -59,7 +67,7 @@ def fetch_rosetta_tiles(path_pattern: str) -> list:
     """
     import urllib.request
     q = (
-        '{ Get { ISMA_Quantum(where: { operator: And operands: ['
+        '{ Get { ' + WEAVIATE_CLASS + '(where: { operator: And operands: ['
         '{ path: ["scale"] operator: Equal valueText: "rosetta" }'
         '{ path: ["source_file"] operator: Like valueText: "%s" }'
         ']} limit: 100) { content source_file dominant_motifs } } }'
@@ -74,7 +82,7 @@ def fetch_rosetta_tiles(path_pattern: str) -> list:
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             result = json.loads(resp.read())
-        tiles = result.get("data", {}).get("Get", {}).get("ISMA_Quantum", []) or []
+        tiles = result.get("data", {}).get("Get", {}).get(WEAVIATE_CLASS, []) or []
     except Exception as e:
         print(f"WARNING: Weaviate fetch failed for {path_pattern}: {e}", file=sys.stderr)
         return []

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -2,7 +2,7 @@
 # install-node.sh: Install taeys-hands node dependencies on a new machine.
 #
 # Installs system tools and the tmux-send script to /usr/local/bin.
-# Run as a user with sudo access on each node (Spark, Jetson, Thor, etc.).
+# Run as a user with sudo access on the target machine.
 #
 # Usage:
 #   bash scripts/install-node.sh

--- a/scripts/tmux-send
+++ b/scripts/tmux-send
@@ -1,18 +1,17 @@
 #!/bin/bash
 # tmux-send: Send text + Enter to a local or remote tmux session.
 #
-# This is Claude-to-Claude communication infrastructure for taeys-hands.
-# All Claude instances (Spark, Jetson, Thor, PALIOS, etc.) that run
-# AT-SPI automation use this script to exchange instructions.
+# Claude-to-Claude communication for taeys-hands multi-node setups.
+# Use this whenever one Claude instance needs to send instructions to another.
 #
 # Usage:
 #   tmux-send <session> "message"              # local (2-arg)
 #   tmux-send <host> <session> "message"       # remote via SSH (3-arg)
 #
 # Examples:
-#   tmux-send taeys-hands "Resume HMM enrichment"
-#   tmux-send jetson jetson-claude "ESCALATION from spark: fix deployed, git pull"
-#   tmux-send thor thor-claude "Next phase: run enrichment loop"
+#   tmux-send claude-worker "Resume the task"
+#   tmux-send worker-node worker-claude "Fix deployed. Run: git pull"
+#   tmux-send supervisor-node supervisor "ESCALATION: task failed, need help"
 #
 # Rules:
 #   - Target sessions MUST be Claude Code instances (worker Claudes)

--- a/tools/extract.py
+++ b/tools/extract.py
@@ -162,9 +162,8 @@ def handle_quick_extract(platform: str, redis_client,
             except (json.JSONDecodeError, TypeError, KeyError) as e:
                 logger.warning(f"Failed to store response in Neo4j: {e}")
 
-    # ── HMM Weaviate triple-write ──
-    # If response looks like HMM enrichment JSON, forward to store endpoint.
-    # This patches Weaviate tiles + creates Neo4j HMMTile + updates Redis index.
+    # ── Optional post-processing webhook ──
+    # If response looks like structured JSON with motifs, forward to store endpoint.
     # Non-blocking: extraction succeeds even if this fails.
     if content and content.strip().startswith('{') and 'motif' in content.lower():
         try:


### PR DESCRIPTION
## What does this PR do?

Full audit of all tracked files — removes private infrastructure details that shouldn't be in a public open-source repo.

## Changes

| File | Issue | Fix |
|------|-------|-----|
| `scripts/build_consultation.py` | Hardcoded internal IP `192.168.100.10`, internal Weaviate class `ISMA_Quantum`, internal paths | All replaced with env vars (`WEAVIATE_URL`, `WEAVIATE_CLASS`, `MOTIFS_SOURCE_PATH`) with generic localhost defaults |
| `scripts/tmux-send` | Examples used internal node names (jetson, thor, PALIOS) | Replaced with generic `worker-node`, `supervisor-node` |
| `scripts/install-node.sh` | Referenced internal cluster node names | Removed |
| `scripts/README.md` | New — generic multi-Claude coordination docs | No internal hostnames |
| `core/tree.py` | Docstring referenced internal project name | Removed |
| `tools/extract.py` | Comment referenced internal service name | Genericized |
| `CLAUDE.md` | Node registry with internal hostnames; internal project name in env var description | Registry moved to `CLAUDE.local.md` (not tracked); descriptions genericized |

## What's intentionally kept

- `PALIOS-TAEY` in LICENSE/README — that's the company/licensor name, appropriate
- `HMM_STORE_URL` env var — kept as a generic optional webhook config point
- All functional code unchanged — only docs/comments/defaults updated

## Not in this repo

`CLAUDE.local.md` holds all cluster-specific config (IPs, hostnames, session names) and is not committed.