### PR TITLE
fix: daemon tmux send-keys timeout leaves text unsubmitted

### DIFF
--- a/monitor/daemon.py
+++ b/monitor/daemon.py
@@ -398,36 +398,40 @@ class MonitorDaemon:
         session = self.tmux_session
         msg = f"Response ready on {platform}. Extract it now with taey_quick_extract('{platform}')"
 
+        def _send(keys, is_hex=False, timeout=3):
+            """Fire send-keys, returning True on success. Ignores TimeoutExpired."""
+            cmd = ['tmux', 'send-keys', '-t', session]
+            if is_hex:
+                cmd += ['-H'] + list(keys)
+            else:
+                cmd += ['--'] + [keys]
+            try:
+                r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+                return r.returncode == 0
+            except subprocess.TimeoutExpired:
+                # Text may already be in the pty buffer — continue to Enter steps.
+                self._log(f"tmux send-keys slow (>{timeout}s) for '{session}' — continuing to Enter")
+                return True  # optimistically assume text was deposited
+            except Exception as e:
+                self._log(f"tmux send-keys error for '{session}': {e}")
+                return False
+
         try:
-            result = subprocess.run(
-                ['tmux', 'send-keys', '-t', session, '--', msg],
-                capture_output=True, text=True, timeout=5,
-            )
-            if result.returncode != 0:
-                self._log(f"tmux send-keys failed for session '{session}': {result.stderr.strip()}")
+            if not _send(msg):
+                self._log(f"tmux send-keys failed for session '{session}'")
                 return
 
             # Tier 1: Escape to dismiss autocomplete
             time.sleep(0.5)
-            subprocess.run(
-                ['tmux', 'send-keys', '-t', session, 'Escape'],
-                capture_output=True, text=True, timeout=5,
-            )
+            _send('Escape')
 
             # Tier 2: Legacy Enter (0x0D)
             time.sleep(0.2)
-            subprocess.run(
-                ['tmux', 'send-keys', '-t', session, 'Enter'],
-                capture_output=True, text=True, timeout=5,
-            )
+            _send('Enter')
 
             # Tier 3: Kitty protocol Enter — ESC[13u (hex: 1b 5b 31 33 75)
             time.sleep(0.1)
-            subprocess.run(
-                ['tmux', 'send-keys', '-t', session, '-H',
-                 '1b', '5b', '31', '33', '75'],
-                capture_output=True, text=True, timeout=5,
-            )
+            _send(('1b', '5b', '31', '33', '75'), is_hex=True)
 
             self._log(f"tmux notification sent to session '{session}' (3-tier submit)")
         except Exception as e:


### PR DESCRIPTION
## Summary

- `tmux send-keys` for the response notification occasionally takes >5s (pty busy while Claude's Ink TUI renders large tool output)
- The broad `except Exception` handler caught `TimeoutExpired` and skipped all Enter key steps
- Result: notification text was deposited in the pane's input buffer but never submitted

## Fix

- Extract send-keys into a `_send()` helper that handles `TimeoutExpired` separately
- On timeout, logs a warning and returns `True` (optimistic — text likely already in pty buffer)
- Enter key steps (Tier 1/2/3) always execute regardless of text-send speed

## Test plan

- [ ] Trigger a response while Claude Code pane is rendering large output
- [ ] Verify notification is submitted even when initial send-keys is slow
- [ ] Verify daemon log shows "slow" warning rather than "failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)