### PR TITLE
fix: list_sessions hook + YAML mismatch visibility

### DIFF
--- a/.claude/hooks/mark_list_sessions_complete.py
+++ b/.claude/hooks/mark_list_sessions_complete.py
@@ -28,17 +28,16 @@ def main():
 
     tool_result = data.get("tool_result", {})
 
-    # Only store checkpoint if list_sessions succeeded
+    # Only store checkpoint if list_sessions succeeded (no error key)
     if isinstance(tool_result, str):
         try:
             result_data = json.loads(tool_result)
         except Exception:
-            result_data = {}
+            result_data = {"error": "parse_failed"}
     else:
         result_data = tool_result if isinstance(tool_result, dict) else {}
 
-    success = result_data.get("success", False)
-    if not success:
+    if "error" in result_data:
         sys.exit(0)
 
     r = get_redis()

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,11 @@
       "type": "stdio",
       "command": "/usr/bin/python3",
       "args": ["server.py"],
-      "env": {}
+      "env": {
+        "NEO4J_URI": "bolt://10.0.0.163:7689",
+        "REDIS_HOST": "192.168.100.10",
+        "REDIS_PORT": "6379"
+      }
     }
   }
 }

--- a/tools/dropdown.py
+++ b/tools/dropdown.py
@@ -283,10 +283,19 @@ def handle_select_dropdown(platform: str, dropdown: str,
     yaml_diff = _check_yaml_mismatch(platform, dropdown, items)
     if yaml_diff:
         result['yaml_mismatch'] = yaml_diff
+        # Make mismatch highly visible — override instruction to force attention
+        live_only = yaml_diff.get('live_only', [])
+        yaml_only = yaml_diff.get('yaml_only', [])
+        mismatch_msg = (
+            f"ACTION REQUIRED: Platform YAML is out of sync with live dropdown.\n"
+            f"  Live items not in YAML: {live_only}\n"
+            f"  YAML items not found live: {yaml_only}\n"
+            f"  Update platforms/{platform}.yaml to match live state before proceeding."
+        )
+        result['instruction'] = mismatch_msg
         logger.warning(
             f"YAML mismatch on {platform}/{dropdown}: "
-            f"live_only={yaml_diff.get('live_only', [])}, "
-            f"yaml_only={yaml_diff.get('yaml_only', [])}"
+            f"live_only={live_only}, yaml_only={yaml_only}"
         )
 
     return result
@@ -371,7 +380,10 @@ def _check_yaml_mismatch(platform: str, dropdown_name: str,
     if yaml_only:
         result['yaml_only'] = yaml_only
         result['yaml_only_count'] = len(yaml_only)
-    result['WARNING'] = 'Platform YAML may be stale. Update platforms/*.yaml to match live state.'
+    result['WARNING'] = (
+        'Platform YAML is out of sync with live dropdown. '
+        'Update platforms/*.yaml to match live state before selecting.'
+    )
     return result
 
 


### PR DESCRIPTION
## Summary
- **mark_list_sessions_complete.py**: checked `result_data.get("success")` which never matched — aligned with mark_send_complete.py pattern (check absence of `error`)
- **dropdown YAML mismatch**: detection existed but was buried in JSON return. Now overrides instruction with ACTION REQUIRED when mismatch found
- **.mcp.json**: Added Neo4j/Redis env vars for Mira migration

Bug 2 (Perplexity dropdown missing file upload items) is **not reproducible** — all 6 items visible in live AT-SPI tree. Likely transient.

## Test plan
- [ ] Verify mark_list_sessions_complete sets checkpoint after taey_list_sessions
- [ ] Verify YAML mismatch shows ACTION REQUIRED in dropdown results

🤖 Generated with [Claude Code](https://claude.com/claude-code)