### PR TITLE
fix: daemon notifies wrong tmux session (NODE_ID detection)

### DIFF
--- a/monitor/daemon.py
+++ b/monitor/daemon.py
@@ -27,10 +27,26 @@ from typing import Optional, Dict, Any
 
 # Instance-scoped key prefix (must match storage/redis_pool.py logic)
 def _detect_node_id() -> str:
-    """Auto-detect instance ID: TAEY_NODE_ID > tmux session > hostname."""
+    """Auto-detect instance ID: TAEY_NODE_ID > parent TTY tmux session > hostname.
+
+    Must match storage/redis_pool.py detection logic.
+    """
     explicit = os.environ.get('TAEY_NODE_ID')
     if explicit:
         return explicit
+    try:
+        parent_tty = os.readlink(f'/proc/{os.getppid()}/fd/0')
+        result = subprocess.run(
+            ['tmux', 'list-panes', '-a', '-F', '#{pane_tty} #{session_name}'],
+            capture_output=True, text=True, timeout=2,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.strip().splitlines():
+                parts = line.split(' ', 1)
+                if len(parts) == 2 and parts[0] == parent_tty:
+                    return parts[1]
+    except Exception:
+        pass
     try:
         result = subprocess.run(
             ['tmux', 'display-message', '-p', '#S'],

--- a/storage/redis_pool.py
+++ b/storage/redis_pool.py
@@ -65,10 +65,31 @@ def get_client() -> redis.Redis:
 
 
 def _detect_node_id() -> str:
-    """Auto-detect instance ID: TAEY_NODE_ID > tmux session > hostname."""
+    """Auto-detect instance ID: TAEY_NODE_ID > parent TTY tmux session > hostname.
+
+    'tmux display-message -p #S' is unreliable for MCP subprocesses — it
+    returns whichever tmux client was most recently active, not the one that
+    spawned this process.  Instead, map the parent process's TTY to a tmux
+    session via 'tmux list-panes', which is deterministic.
+    """
     explicit = os.environ.get('TAEY_NODE_ID')
     if explicit:
         return explicit
+    try:
+        # Map parent's TTY → tmux session name (reliable for MCP subprocesses)
+        parent_tty = os.readlink(f'/proc/{os.getppid()}/fd/0')
+        result = subprocess.run(
+            ['tmux', 'list-panes', '-a', '-F', '#{pane_tty} #{session_name}'],
+            capture_output=True, text=True, timeout=2,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.strip().splitlines():
+                parts = line.split(' ', 1)
+                if len(parts) == 2 and parts[0] == parent_tty:
+                    return parts[1]
+    except Exception:
+        pass
+    # Fallback: try tmux display-message (works in interactive tmux shells)
     try:
         result = subprocess.run(
             ['tmux', 'display-message', '-p', '#S'],


### PR DESCRIPTION
## Summary
`tmux display-message -p '#S'` returns whichever tmux client was most recently active, not the session that spawned the MCP subprocess. This caused ALL daemon notifications to go to 'weaver' regardless of which Claude session triggered them.

**Fix**: Map parent process TTY (`/proc/<ppid>/fd/0`) to tmux session via `tmux list-panes -a`. Deterministic — each MCP subprocess inherits the correct PTY from its Claude Code parent.

Verified: PID on pts/3 → 'claude', PID on pts/6 → 'weaver'.

## Test plan
- [ ] Restart MCP server in claude session, send message, verify daemon notifies 'claude'
- [ ] Same for weaver session

🤖 Generated with [Claude Code](https://claude.com/claude-code)