### PR TITLE
fix: extract_response plan + daemon node_id scoping

### DIFF
--- a/monitor/daemon.py
+++ b/monitor/daemon.py
@@ -60,10 +60,16 @@ def _detect_node_id() -> str:
 
 _NODE_ID = _detect_node_id()
 
+# Overridden by --tmux-session in main() to match the spawning MCP server's
+# node_id. The auto-detect above is unreliable for background daemon processes
+# because tmux display-message returns whichever session was most recently
+# active, not the one that spawned this daemon.
+_EFFECTIVE_NODE_ID = _NODE_ID
+
 
 def _node_key(suffix: str) -> str:
     """Instance-scoped Redis key (matches storage.redis_pool.node_key)."""
-    return f"taey:{_NODE_ID}:{suffix}"
+    return f"taey:{_EFFECTIVE_NODE_ID}:{suffix}"
 
 # =========================================================================
 # Load .env (daemon runs as subprocess, doesn't inherit server's env loading)
@@ -706,6 +712,14 @@ def main():
                              'If new stop button appears during settle, monitors second cycle.')
 
     args = parser.parse_args()
+
+    # Use --tmux-session as authoritative node_id for Redis key scoping.
+    # The MCP server resolves this correctly via parent TTY → tmux session mapping.
+    # The daemon's own _detect_node_id() is unreliable (background process,
+    # parent fd/0 is a socket, display-message is non-deterministic).
+    if args.tmux_session:
+        global _EFFECTIVE_NODE_ID
+        _EFFECTIVE_NODE_ID = args.tmux_session
 
     daemon = MonitorDaemon(
         platform=args.platform,

--- a/tools/plan.py
+++ b/tools/plan.py
@@ -37,6 +37,8 @@ def handle_plan(platform: str, action: str, params: Dict,
         return _update_plan(params.get('plan_id'), params, redis_client)
     elif action == 'send_message':
         return _create_plan(platform, action, params, redis_client)
+    elif action == 'extract_response':
+        return _create_extract_plan(platform, params, redis_client)
     else:
         return {"error": f"Unknown plan action: {action}", "success": False}
 
@@ -131,6 +133,54 @@ def _create_plan(platform: str, action: str, params: Dict,
         "required_state": plan['required_state'],
         "attachments": attachments_list,
         "next_step": f"Call taey_inspect to see current state",
+    }
+
+
+def _create_extract_plan(platform: str, params: Dict,
+                         redis_client) -> Dict[str, Any]:
+    """Create an extraction-only plan (no send_message).
+
+    Used when a response is already pending on a platform and just needs
+    to be extracted. Simpler than send_message plans — only needs platform.
+    """
+    if not redis_client:
+        return {"error": "Redis not available", "success": False}
+
+    plan_id = str(uuid.uuid4())[:8]
+
+    plan = {
+        'plan_id': plan_id,
+        'platform': platform,
+        'action': 'extract_response',
+        'session': params.get('session', 'current'),
+        'message': None,
+        'attachments': [],
+        'required_state': {},
+        'current_state': None,
+        'steps': [{"action": "extract", "platform": platform}],
+        'status': 'ready',
+        'navigated': False,
+        'created_at': time.time(),
+    }
+
+    redis_client.set(node_key(f"plan:{plan_id}"), json.dumps(plan))
+    redis_client.set(node_key(f"plan:current:{platform}"), plan_id)
+
+    redis_client.setex(node_key(f"plan:{platform}"), 1800, json.dumps({
+        'id': plan_id, 'platform': platform, 'action': 'extract_response',
+        'session': plan['session'], 'message': None,
+        'model': None, 'mode': None,
+        'tools': [], 'attachments': [],
+        'validated': True, 'created_at': time.time(),
+    }))
+
+    return {
+        "success": True,
+        "plan_id": plan_id,
+        "platform": platform,
+        "action": "extract_response",
+        "steps": plan['steps'],
+        "next_step": f"Call taey_quick_extract('{platform}') to extract the response",
     }
 
 


### PR DESCRIPTION
## Summary
- Add `extract_response` action dispatch to `taey_plan` — was in MCP schema but not implemented, causing "Unknown action" errors
- Fix daemon Redis key scoping: `--tmux-session` now overrides unreliable `_detect_node_id()` for background processes, preventing notification bleed across instances

## Test plan
- [ ] Verify `taey_plan(action='extract_response', platform='chatgpt')` creates a plan successfully
- [ ] Verify daemon spawned from different tmux sessions uses correct Redis key prefix
- [ ] Verify existing `send_message` / `get` / `update` plan actions still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)