### PR TITLE
fix: remove deleted hook references from settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -77,11 +77,6 @@
           {
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/check_notifications.py\""
-          },
-          {
-            "type": "command",
-            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/task_reporter.py\"",
-            "timeout": 5
           }
         ]
       },
@@ -113,17 +108,6 @@
         ]
       }
     ],
-    "Stop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/orch_stop_gate.py\"",
-            "timeout": 10
-          }
-        ]
-      }
-    ]
+    "Stop": []
   }
 }


### PR DESCRIPTION
## Summary
- Remove `task_reporter.py` and `orch_stop_gate.py` from hooks config — files were deleted in security cleanup but references remained, causing errors on every tool call

🤖 Generated with [Claude Code](https://claude.com/claude-code)