### PR TITLE
fix: notification pipeline key mismatch + clean hooks config

### DIFF
--- a/.claude/hooks/check_notifications.py
+++ b/.claude/hooks/check_notifications.py
@@ -22,7 +22,7 @@ import os
 
 # Add hooks directory to path for config import
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from config import get_config, get_redis
+from config import get_config, get_redis, node_key
 
 CFG = get_config()
 
@@ -49,9 +49,10 @@ def get_pending_notifications():
 
     try:
         notifications = []
-        # Pop up to 10 notifications per tool call from taey queue
+        # Pop up to 10 notifications per tool call (node-scoped key)
+        notify_key = node_key("notifications")
         for _ in range(10):
-            notification_json = r.lpop("taey:notifications")
+            notification_json = r.lpop(notify_key)
             if not notification_json:
                 break
             log_debug(f"Raw notification: {repr(notification_json)}")

--- a/.claude/hooks/config.py
+++ b/.claude/hooks/config.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Hook Configuration - Environment variable driven.
+
+All hooks import from here for Redis connections and node identity.
+No hardcoded IPs — reads from environment with localhost defaults.
+
+Usage in hooks:
+    from config import get_config, get_redis, node_key
+"""
+import os
+import socket
+
+
+def get_config() -> dict:
+    """Get configuration from environment variables."""
+    return {
+        'redis_host': os.environ.get('REDIS_HOST', '127.0.0.1'),
+        'redis_port': int(os.environ.get('REDIS_PORT', '6379')),
+        'neo4j_uri': os.environ.get('NEO4J_URI', 'bolt://localhost:7687'),
+        'agent_id': detect_node_id(),
+    }
+
+
+def get_redis():
+    """Get configured Redis connection."""
+    try:
+        import redis
+        cfg = get_config()
+        return redis.Redis(
+            host=cfg['redis_host'],
+            port=cfg['redis_port'],
+            decode_responses=True,
+            socket_timeout=2,
+        )
+    except ImportError:
+        return None
+
+
+def detect_node_id() -> str:
+    """Auto-detect instance ID: TAEY_NODE_ID > tmux session > hostname."""
+    explicit = os.environ.get('TAEY_NODE_ID')
+    if explicit:
+        return explicit
+    try:
+        import subprocess
+        result = subprocess.run(
+            ['tmux', 'display-message', '-p', '#S'],
+            capture_output=True, text=True, timeout=2,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return socket.gethostname()
+
+
+def node_key(suffix: str) -> str:
+    """Instance-scoped Redis key: taey:{node_id}:{suffix}."""
+    return f"taey:{detect_node_id()}:{suffix}"

--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,6 @@ CLAUDE.local.md
 
 # Cluster-specific hooks (local customization)
 .claude/hooks/worker-*.sh
-.claude/hooks/config.py
-.claude/hooks/orch_stop_gate.py
-.claude/hooks/task_reporter.py
 .claude/agent_operations.md
 
 # Local infrastructure config


### PR DESCRIPTION
## Summary
- Rebuild `.claude/hooks/config.py` using env vars only (no hardcoded IPs) — original was lost during security cleanup
- Fix Redis key mismatch: hook now reads from `taey:{node_id}:notifications` matching daemon's write key
- Remove canvas stop platform check (now generic)
- Fix dropdown baseline overwrite-before-compare bug

## Key fix
The daemon wrote notifications to `taey:{node_id}:notifications` but the hook read from `taey:notifications`. Keys never matched — Redis notifications were silently lost. This is why tmux injection was the only working notification path.

## Test plan
- [x] `config.py` imports verified (`get_redis`, `node_key`, `detect_node_id`)
- [x] Notification delivered via Redis on first tool call after fix
- [ ] Verify daemon + hook use same key on fresh session

🤖 Generated with [Claude Code](https://claude.com/claude-code)