### PR TITLE
feat: consultation.py full-cycle script (#39)

### DIFF
--- a/scripts/consultation.py
+++ b/scripts/consultation.py
@@ -584,12 +584,27 @@ def main():
             result['attachment'] = pkg_path
 
     # Step 3: Model/mode selection (if requested)
-    # TODO: implement model/mode selection via dropdown
-    # For now, log a warning if requested
-    if args.model:
-        logger.warning(f"Model selection ({args.model}) not yet implemented in consultation.py")
-    if args.mode:
-        logger.warning(f"Mode selection ({args.mode}) not yet implemented in consultation.py")
+    if args.model or args.mode:
+        logger.info(f"Step 3: Selecting model={args.model} mode={args.mode}")
+        from core.mode_select import select_mode_model
+        ff = find_firefox()
+        doc = get_doc(force_refresh=True)
+        sel_result = select_mode_model(
+            platform, mode=args.mode, model=args.model,
+            doc=doc, firefox=ff,
+        )
+        if sel_result.get('success'):
+            logger.info(f"Mode/model selected: {sel_result.get('selected_mode', sel_result.get('matched', '?'))}")
+            if sel_result.get('timeout'):
+                timeout = sel_result['timeout']
+                logger.info(f"Timeout adjusted to {timeout}s for this mode")
+            result['mode_selection'] = sel_result
+        else:
+            logger.warning(f"Mode/model selection failed: {sel_result.get('error')}")
+            logger.warning(f"Available modes: {sel_result.get('available_modes', 'unknown')}")
+            result['mode_selection'] = sel_result
+            # Don't fail -- proceed with default mode
+        time.sleep(1)
 
     # Step 4: Send prompt
     logger.info("Step 4: Send prompt")


### PR DESCRIPTION
## Standalone consultation script

Full plan->inspect->attach->send->wait->extract pipeline as a CLI tool.

### Usage
```bash
python3 scripts/consultation.py --platform gemini \
    --attach file.md --message 'Analyze this'

# With display selection (multi-display Mira)
python3 scripts/consultation.py --platform gemini --display :4 \
    --message 'Quick question'
```

### Features
- Same proven code paths as hmm_bot and display workers
- Auto-prepends identity files, consolidates attachments
- Stop-button polling for response detection
- Ctrl+End scroll + copy button extraction
- Neo4j storage (prompt + response + RESPONDS_TO)
- ISMA ingestion (auto_ingest + ingest_transcript)
- JSON result on stdout

### Test plan
```bash
# On Mira, any display
python3 scripts/consultation.py --platform gemini --display :4 \
    --message 'Say hello in one sentence' --no-neo4j --no-isma
```

Closes #39