### PR TITLE
cleanup: remove RemoteFirefox/subprocess_scan dead code (#40)

### DIFF
--- a/core/atspi.py
+++ b/core/atspi.py
@@ -1,29 +1,22 @@
 """AT-SPI desktop and Firefox discovery.
 
-Multi-display mode: when PLATFORM_DISPLAYS is set (Mira), each platform
-has its own display/D-Bus. Tree operations are routed through subprocess
-scanning with the correct env. Returns _RemoteFirefox/_RemoteDocument
-sentinels that callers detect via getattr(obj, '_remote', False).
+Multi-display mode: each platform runs on its own display with a dedicated
+per-display worker process (workers/display_worker.py). Workers have the
+correct DISPLAY and AT-SPI bus set in their environment, so all AT-SPI
+calls go through the direct local path. The MCP server dispatches tool
+calls to the correct worker via Unix socket IPC (workers/manager.py).
 """
 
-import json
 import os
 import logging
-import subprocess
-import sys
 
 import gi
 gi.require_version('Atspi', '2.0')
 from gi.repository import Atspi
 
-from core.platforms import (URL_PATTERNS, _EXTRA_URL_PATTERNS,
-                            get_platform_display, get_platform_bus,
-                            get_platform_firefox_pid)
+from core.platforms import (URL_PATTERNS, _EXTRA_URL_PATTERNS)
 
 logger = logging.getLogger(__name__)
-
-# Path to the subprocess scanner script
-_SCANNER_SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), '_atspi_subprocess.py')
 
 
 def detect_display() -> str:
@@ -106,86 +99,6 @@ def find_all_firefox(pid: int = None):
     return apps
 
 
-def subprocess_scan(platform: str, cmd: str = 'find_firefox') -> dict | None:
-    """Run AT-SPI scan as subprocess on the platform's dedicated display.
-
-    Used in multi-display mode (Mira) where each platform runs on a
-    separate Xvfb with its own D-Bus/AT-SPI bus.
-    """
-    display = get_platform_display(platform)
-    if not display:
-        return None
-    bus = get_platform_bus(platform)
-    env = {**os.environ, 'DISPLAY': display}
-    if bus:
-        env['AT_SPI_BUS_ADDRESS'] = bus
-        env['DBUS_SESSION_BUS_ADDRESS'] = bus
-    try:
-        r = subprocess.run(
-            [sys.executable, _SCANNER_SCRIPT, cmd, platform],
-            env=env, capture_output=True, text=True, timeout=15,
-        )
-        if r.returncode == 0 and r.stdout.strip():
-            return json.loads(r.stdout.strip())
-        if r.stderr:
-            logger.warning(f"Subprocess scanner stderr: {r.stderr[:200]}")
-    except Exception as e:
-        logger.error(f"Subprocess scan failed for {platform} on {display}: {e}")
-    return None
-
-
-class _RemoteFirefox:
-    """Sentinel for a Firefox on a different display. Carries PID and display
-    info so that callers can route operations through subprocess scanning.
-
-    Callers detect via: getattr(obj, '_remote', False)
-    """
-    def __init__(self, platform, pid, display, url=None):
-        self._platform = platform
-        self._pid = pid
-        self._display = display
-        self._url = url
-        self._remote = True
-
-    def get_name(self):
-        return 'Firefox'
-
-    def get_process_id(self):
-        return self._pid
-
-    def get_child_count(self):
-        return 0
-
-    def get_child_at_index(self, i):
-        return None
-
-
-class _RemoteDocument:
-    """Sentinel for a document on a different display."""
-    def __init__(self, platform, url, display):
-        self._platform = platform
-        self._url = url
-        self._display = display
-        self._remote = True
-
-    def get_role_name(self):
-        return 'document web'
-
-    def get_name(self):
-        return ''
-
-    def get_state_set(self):
-        return None
-
-    def get_child_count(self):
-        return 0
-
-    def get_child_at_index(self, i):
-        return None
-
-    def get_component_iface(self):
-        return None
-
 
 def find_firefox_for_platform(platform: str, pid: int = None):
     """Find the Firefox instance that has a document matching the given platform.
@@ -193,19 +106,9 @@ def find_firefox_for_platform(platform: str, pid: int = None):
     If pid is given, restricts search to that process only.
     Falls back to find_firefox() if only one instance exists.
 
-    Multi-display mode: if PLATFORM_DISPLAYS maps this platform to a dedicated
-    display, uses subprocess scanning on that display's AT-SPI bus."""
-    # Multi-display mode: subprocess scan on the platform's display
-    if pid is None and get_platform_display(platform):
-        info = subprocess_scan(platform, 'find_firefox')
-        if info and info.get('pid'):
-            return _RemoteFirefox(platform, info['pid'],
-                                 get_platform_display(platform),
-                                 info.get('url'))
-        elif info:
-            logger.warning(f"Subprocess found no Firefox for {platform}: {info}")
-        # Fall through to local scan
-
+    Multi-display: per-display workers handle routing. Each worker has
+    the correct DISPLAY/AT-SPI bus, so this function always uses the
+    direct local AT-SPI path."""
     all_ff = find_all_firefox(pid=pid)
     if not all_ff:
         return None

--- a/core/config.py
+++ b/core/config.py
@@ -162,16 +162,16 @@ def get_validation(platform: str) -> dict:
 
 
 def scan_platform_tree(platform: str) -> tuple:
-    """Scan the AT-SPI tree for a platform, handling multi-display routing.
+    """Scan the AT-SPI tree for a platform via direct AT-SPI.
 
     Returns (elements: list[dict], url: str|None, error: str|None).
 
-    In multi-display mode (Mira): routes through subprocess scanner.
-    In single-display mode (Thor): uses direct AT-SPI scan.
+    Multi-display is handled by per-display workers — each worker
+    has the correct DISPLAY/AT-SPI bus, so this always uses the
+    direct local path.
 
     Elements are raw dicts with name/role/x/y/states — no atspi_obj
-    (subprocess results are serialized). Callers should not depend on
-    atspi_obj being present.
+    (stripped for serialization safety).
     """
     from core import atspi
     from core.tree import find_elements
@@ -181,17 +181,6 @@ def scan_platform_tree(platform: str) -> tuple:
     if not firefox:
         return [], None, f'Firefox not found for {platform}'
 
-    # Multi-display: subprocess scan
-    if getattr(firefox, '_remote', False):
-        scan_result = atspi.subprocess_scan(platform, 'scan')
-        if not scan_result or scan_result.get('error'):
-            err = scan_result.get('error', 'Subprocess scan failed') if scan_result else 'Subprocess scan failed'
-            return [], None, err
-        elements = scan_result.get('elements', [])
-        url = scan_result.get('url')
-        return elements, url, None
-
-    # Local: direct AT-SPI scan
     doc = atspi.get_platform_document(firefox, platform)
     if not doc:
         return [], None, f'{platform} document not found'

--- a/tools/attach.py
+++ b/tools/attach.py
@@ -39,26 +39,13 @@ def _scan_elements_for_platform(platform: str) -> List[Dict]:
 
 
 def _scan_menu_items_for_platform(platform: str) -> List[Dict]:
-    """Scan for dropdown/menu items after opening a trigger, multi-display aware.
+    """Scan for dropdown/menu items after opening a trigger.
 
-    On local: uses find_menu_items(firefox, doc) which looks for menu containers.
-    On multi-display: uses subprocess scan then filters for menu item roles.
+    Uses find_menu_items(firefox, doc) which searches menu containers
+    in 4 passes (doc strict, doc no-SHOWING, containerless, Firefox root).
     Returns list of element dicts.
     """
     firefox = atspi.find_firefox_for_platform(platform)
-
-    # Multi-display: subprocess scan, filter for menu-like items
-    if getattr(firefox, '_remote', False):
-        elements = _scan_elements_for_platform(platform)
-        _MENU_ROLES = {'menu item', 'radio menu item', 'check menu item',
-                       'list item', 'option'}
-        items = [e for e in elements
-                 if e.get('name', '').strip() and e.get('role', '') in _MENU_ROLES]
-        if items:
-            items.sort(key=lambda x: x.get('y', 0))
-        return items
-
-    # Local: direct AT-SPI scan via find_menu_items
     if not firefox:
         return []
     doc = atspi.get_platform_document(firefox, platform)
@@ -870,14 +857,9 @@ def handle_attach(platform: str, file_path: str,
         return {"error": f"{platform} does not support file attachments"}
 
     # AT-SPI menu platforms: click trigger, scan for menu items or dialog
-    # Use element cache (populated by inspect) for button coords — works on multi-display
     firefox = atspi.find_firefox_for_platform(platform)
-    if not getattr(firefox, '_remote', False):
-        doc = atspi.get_platform_document(firefox, platform) if firefox else None
-        btn_coords = _get_attach_button_coords(doc, platform) if doc else None
-    else:
-        # Multi-display: button is in element cache from subprocess inspect
-        btn_coords = _get_attach_button_coords(None, platform)
+    doc = atspi.get_platform_document(firefox, platform) if firefox else None
+    btn_coords = _get_attach_button_coords(doc, platform) if doc else None
 
     if not btn_coords:
         return {"error": f"Attach button not found for {platform}",

--- a/tools/inspect.py
+++ b/tools/inspect.py
@@ -353,76 +353,9 @@ def handle_inspect(platform: str, redis_client, scroll: str = "bottom",
     # Load platform config — needed for fence_after and element filtering
     _pcfg = get_platform_config(platform)
 
-    # ─── Multi-display path: subprocess scan with YAML filtering ───
-    if getattr(firefox, '_remote', False):
-        scan_result = atspi.subprocess_scan(platform, 'scan')
-        if not scan_result or scan_result.get('error'):
-            result['error'] = scan_result.get('error', 'Subprocess scan failed') if scan_result else 'Subprocess scan failed'
-            return result
-
-        url = scan_result.get('url')
-        result['url'] = url
-        elements_json = scan_result.get('elements', [])
-
-        # Truncate long names
-        for e in elements_json:
-            name = e.get('name', '')
-            if len(name) > 200:
-                e['name'] = name[:200] + '...'
-
-        # Apply YAML filtering — same as local path
-        pre_filter = len(elements_json)
-        noise_removed = 0
-        if _pcfg.get('element_filter') or _pcfg.get('element_map'):
-            elements_json, new_elements = _apply_element_filter(elements_json, _pcfg)
-            noise_removed = pre_filter - len(elements_json)
-            if new_elements:
-                result['new_elements'] = [{'name': e.get('name', ''), 'role': e.get('role', ''),
-                                           'x': e.get('x'), 'y': e.get('y')} for e in new_elements]
-
-        copy_count = scan_result.get('copy_button_count', 0)
-        result['state']['copy_button_count'] = copy_count
-        result['state']['element_count'] = len(elements_json)
-        result['state']['total_before_filter'] = scan_result.get('total', pre_filter)
-        if noise_removed:
-            result['state']['noise_removed'] = noise_removed
-        result['controls'] = elements_json
-
-        attached = _detect_attachments(elements_json, elements_json)
-        if attached:
-            result['attachments'] = attached
-
-        sc = _check_structure_change(platform, elements_json, redis_client)
-        if sc:
-            result['structure_change'] = sc
-
-        if redis_client:
-            redis_client.set(node_key(f"inspect:{platform}"), json.dumps({
-                'url': url, 'state': result['state'],
-                'controls': elements_json, 'timestamp': time.time(),
-            }))
-            redis_client.setex(node_key(f"checkpoint:{platform}:inspect"), 1800, json.dumps({
-                'url': url, 'copy_button_count': copy_count,
-                'element_count': len(elements_json), 'timestamp': time.time(),
-            }))
-
-        result['multi_display'] = True
-        result['display'] = firefox._display
-        result['success'] = True
-        result['atspi_note'] = "Menu items (Back, Forward, Reload) are browser chrome - ignore them."
-
-        if plan and plan.get('required_state'):
-            req = plan['required_state']
-            cur = plan.get('current_state')
-            pr = {'plan_id': plan_id, 'required_state': req,
-                  'current_state': cur, 'status': plan.get('status', 'unknown')}
-            if cur is None:
-                pr['WARNING'] = "PLAN EXISTS but current_state NOT SET. Read elements, call taey_plan(update)."
-            result['plan_requirements'] = pr
-
-        return result
-
-    # ─── Local path: direct AT-SPI scan ───
+    # ─── Direct AT-SPI scan ───
+    # Multi-display is handled by per-display workers — this always runs
+    # on the correct bus.
     doc = atspi.get_platform_document(firefox, platform)
     if not doc:
         result['error'] = f"Could not find {platform} document"


### PR DESCRIPTION
Removes unreachable multi-display proxy infrastructure. Per-display workers handle all routing now.

### Removed
- `_RemoteFirefox` and `_RemoteDocument` sentinel classes
- `subprocess_scan()` function and `_SCANNER_SCRIPT` constant
- All `getattr(firefox, '_remote', False)` checks
- Subprocess scan paths in `scan_platform_tree()`, `handle_inspect()`, `_scan_menu_items_for_platform()`, `handle_attach()`

### Kept
- `core/_atspi_subprocess.py` — kept for reference
- `core/platforms.py` — `_PLATFORM_DISPLAYS` still used by worker manager

### Why this is safe
Workers clear `_PLATFORM_DISPLAYS` in their env, so `find_firefox_for_platform()` never creates sentinels. On single-display, the dict was always empty. These code paths were unreachable.

Closes #40