### PR TITLE
fix: HARD GATE — verify mode in AT-SPI tree before send (#61)

### DIFF
--- a/scripts/consultation.py
+++ b/scripts/consultation.py
@@ -618,11 +618,72 @@ def main():
                 logger.info(f"Timeout adjusted to {timeout}s for this mode")
             result['mode_selection'] = sel_result
         else:
-            logger.warning(f"Mode/model selection failed: {sel_result.get('error')}")
-            logger.warning(f"Available modes: {sel_result.get('available_modes', 'unknown')}")
+            logger.error(f"Mode/model selection FAILED: {sel_result.get('error')}")
+            logger.error(f"Available modes: {sel_result.get('available_modes', 'unknown')}")
+            result['error'] = f"mode_selection_failed: {sel_result.get('error')}"
             result['mode_selection'] = sel_result
-            # Don't fail -- proceed with default mode
+            print(json.dumps(result, indent=2))
+            sys.exit(1)
         time.sleep(1)
+
+    # Step 3b: VERIFY mode/model in AT-SPI tree before send.
+    # This is the hard gate — DO NOT send without verification.
+    # Same principle as the MCP audit step.
+    if args.model or args.mode:
+        logger.info("Step 3b: Verifying mode/model in AT-SPI tree")
+        ff = find_firefox()
+        doc = get_doc(force_refresh=True)
+        if doc:
+            from core.tree import find_elements as _fe
+            from core.config import get_platform_config as _gpc, get_element_spec as _ges
+            _config = _gpc(platform)
+            _elements = _fe(doc)
+            verified = False
+            verify_method = 'none'
+
+            # Method 1: Check for deselect button (Gemini tools like Deep Think)
+            # If 'Deselect {mode}' button exists, mode is active
+            target_mode = args.mode or args.model
+            deselect_name = f"Deselect {target_mode.replace('_', ' ').title()}"
+            for e in _elements:
+                ename = (e.get('name') or '').strip()
+                if ename.lower().startswith('deselect') and \
+                   target_mode.replace('_', ' ').lower() in ename.lower():
+                    logger.info(f"Mode verified via deselect button: {ename}")
+                    verified = True
+                    verify_method = 'deselect_button'
+                    break
+
+            # Method 2: Check menu item checked state
+            if not verified:
+                for e in _elements:
+                    ename = (e.get('name') or '').strip().lower()
+                    if target_mode.replace('_', ' ').lower() in ename and \
+                       'checked' in e.get('states', []):
+                        logger.info(f"Mode verified via checked state: {e.get('name')}")
+                        verified = True
+                        verify_method = 'checked_state'
+                        break
+
+            # Method 3: Use mode_select verification
+            if not verified:
+                from core.mode_select import _verify_selection
+                v = _verify_selection(platform, target_mode, ff, doc)
+                if v.get('verified'):
+                    logger.info(f"Mode verified via mode_select: {v.get('button_name')}")
+                    verified = True
+                    verify_method = 'mode_select_verify'
+
+            if not verified:
+                logger.error(f"HARD STOP: mode '{target_mode}' NOT verified in AT-SPI tree. "
+                             f"Will NOT send without verification.")
+                result['error'] = f"mode_not_verified: '{target_mode}' not confirmed in AT-SPI tree"
+                result['verify_method'] = verify_method
+                print(json.dumps(result, indent=2))
+                sys.exit(1)
+
+            logger.info(f"Mode verification PASSED ({verify_method})")
+            result['mode_verified'] = {'method': verify_method, 'mode': target_mode}
 
     # Step 4: Send prompt
     logger.info("Step 4: Send prompt")


### PR DESCRIPTION
consultation.py now STOPS if mode/model not verified in tree.

1. Mode selection failure = FATAL (was: warning, proceed)
2. New Step 3b: 3-method AT-SPI verification before send
   - Deselect button ('Deselect Deep think')
   - Checked state on menu items
   - mode_select._verify_selection

If all fail: HARD STOP. No sending in wrong mode.

Test: `--platform gemini --mode deep_think --message 'test'`
Should verify Deep Think is active before sending.

Closes #61