### PR TITLE
feat: consultation follow-up support for existing sessions (#63)

### DIFF
--- a/scripts/consultation.py
+++ b/scripts/consultation.py
@@ -27,6 +27,17 @@ Usage:
     python3 scripts/consultation.py --platform gemini \
         --message "Hello" --output /tmp/response.md
 
+    # Follow-up on existing session (no identity files, no mode selection)
+    python3 scripts/consultation.py --platform perplexity \
+        --session-url "https://www.perplexity.ai/search/abc123" \
+        --message "Can you elaborate on point 3?"
+
+    # Follow-up with attachment
+    python3 scripts/consultation.py --platform gemini \
+        --session-url "https://gemini.google.com/app/abc123" \
+        --attach extra_context.md \
+        --message "Here is additional context"
+
 Environment:
     DISPLAY              X11 display (auto-detected or --display)
     REDIS_HOST           Redis host (default: 127.0.0.1)
@@ -113,6 +124,9 @@ def parse_args():
                         help='Model to select (e.g. "Pro", "auto")')
     parser.add_argument('--mode', default=None,
                         help='Mode to select (e.g. "Deep Research", "Deep Think")')
+    parser.add_argument('--session-url', default=None,
+                        help='Existing session URL for follow-up (skips fresh session, '
+                             'identity files, and model/mode selection)')
     parser.add_argument('--display', default=None,
                         help='X11 display (e.g. :4). Auto-detected if not set.')
     parser.add_argument('--output', default=None,
@@ -201,6 +215,28 @@ def get_doc(force_refresh=False):
     if not ff:
         return None
     return atspi.get_platform_document(ff, args.platform)
+
+
+def navigate_to_session_url(platform: str, url: str) -> bool:
+    """Navigate to an existing session URL for follow-up."""
+    _close_stale_file_dialogs()
+    inp.focus_firefox()
+    time.sleep(0.3)
+    inp.press_key('Escape')
+    time.sleep(0.2)
+    inp.press_key('ctrl+l')
+    time.sleep(0.3)
+    inp.press_key('ctrl+a')
+    time.sleep(0.1)
+    inp.type_text(url, delay_ms=5)
+    time.sleep(0.3)
+    inp.press_key('Return')
+    time.sleep(8)
+
+    doc = get_doc(force_refresh=True)
+    if not doc:
+        logger.warning("AT-SPI doc not found after navigation -- continuing anyway")
+    return True
 
 
 def navigate_fresh_session(platform: str) -> bool:
@@ -549,22 +585,37 @@ def main():
     logger.info(f"  Message: {message[:100]}{'...' if len(message) > 100 else ''}")
     logger.info(f"  Attachments: {len(attachments)} files")
     logger.info(f"  Display: {os.environ.get('DISPLAY', '(not set)')}")
+    if args.session_url:
+        logger.info(f"  Follow-up URL: {args.session_url}")
     if args.model:
         logger.info(f"  Model: {args.model}")
     if args.mode:
         logger.info(f"  Mode: {args.mode}")
 
+    is_followup = bool(args.session_url)
+
     result = {
         'platform': platform, 'success': False,
         'message_length': len(message), 'attachments': attachments,
+        'followup': is_followup,
     }
+    if is_followup:
+        result['session_url'] = args.session_url
 
-    # Step 1: Navigate to fresh session
-    logger.info("Step 1: Navigate to fresh session")
-    if not navigate_fresh_session(platform):
-        result['error'] = 'navigation_failed'
-        print(json.dumps(result, indent=2))
-        sys.exit(1)
+    # ── Step 1: Navigation ────────────────────────────────────────────────
+    if is_followup:
+        logger.info("Step 1: Navigate to existing session (follow-up)")
+        logger.info(f"  URL: {args.session_url}")
+        if not navigate_to_session_url(platform, args.session_url):
+            result['error'] = 'navigation_failed'
+            print(json.dumps(result, indent=2))
+            sys.exit(1)
+    else:
+        logger.info("Step 1: Navigate to fresh session")
+        if not navigate_fresh_session(platform):
+            result['error'] = 'navigation_failed'
+            print(json.dumps(result, indent=2))
+            sys.exit(1)
 
     # Step 1b: Clear stale cache and do fresh inspect.
     # Navigation rebuilds the page — cached atspi_obj references from
@@ -581,8 +632,32 @@ def main():
         logger.warning(f"Post-navigation inspect failed: {inspect_result.get('error')}")
         # Non-fatal — attach will try its own discovery
 
-    # Step 2: Build and attach package (identity + user files)
-    if attachments or True:  # Always build package (identity files)
+    # ── Step 2: Attachments ───────────────────────────────────────────────
+    # Follow-ups: NO identity files (KERNEL/IDENTITY). Only attach user files
+    # if explicitly provided with --attach.
+    # Fresh sessions: always build identity package.
+    if is_followup:
+        if attachments:
+            logger.info(f"Step 2: Attaching {len(attachments)} follow-up file(s) (no identity)")
+            # For follow-ups, attach each file directly without identity consolidation.
+            # If multiple files, consolidate them WITHOUT identity prepend.
+            if len(attachments) > 1:
+                pkg_path = _consolidate_attachments(attachments, platform)
+            else:
+                pkg_path = attachments[0]
+
+            if pkg_path and os.path.isfile(pkg_path):
+                logger.info(f"Step 2b: Attaching {os.path.basename(pkg_path)}")
+                if not attach_file(platform, pkg_path):
+                    result['error'] = 'attach_failed'
+                    print(json.dumps(result, indent=2))
+                    sys.exit(1)
+                time.sleep(3)
+                result['attachment'] = pkg_path
+        else:
+            logger.info("Step 2: No attachments for follow-up (skipped)")
+    else:
+        # Fresh session: always build identity package
         logger.info("Step 2: Build attachment package")
         all_files = _prepend_identity_files(attachments, platform)
         if len(all_files) > 1:
@@ -601,8 +676,12 @@ def main():
             time.sleep(3)  # Wait for upload processing
             result['attachment'] = pkg_path
 
-    # Step 3: Model/mode selection (if requested)
-    if args.model or args.mode:
+    # ── Step 3: Model/mode selection (skip for follow-ups) ────────────────
+    # Follow-ups inherit model/mode from the original session.
+    # Only allow explicit model/mode override if the user passes the flags.
+    if is_followup and not args.model and not args.mode:
+        logger.info("Step 3: Model/mode selection skipped (follow-up)")
+    elif args.model or args.mode:
         logger.info(f"Step 3: Selecting model={args.model} mode={args.mode}")
         from core.mode_select import select_mode_model
         ff = find_firefox()
@@ -695,10 +774,11 @@ def main():
     # Step 4b: Register monitor session + Neo4j storage
     # This enables the central monitor to detect response completion
     # and send notifications via Redis.
-    url = None
-    doc = get_doc()
-    if doc:
-        url = atspi.get_document_url(doc)
+    url = args.session_url  # Use known URL for follow-ups
+    if not url:
+        doc = get_doc()
+        if doc:
+            url = atspi.get_document_url(doc)
     session_id = message_id = None
     if not args.no_neo4j and neo4j_client and url:
         try:

--- a/server.py
+++ b/server.py
@@ -243,7 +243,18 @@ def _h_prepare(args, rc):
 
 def _h_plan(args, rc):
     err = _validate_required(args, 'action')
-    return err or handle_plan(args['platform'], args['action'], args.get('params', {}), rc)
+    # MCP clients may send params as nested object OR flatten fields to top level.
+    # Accept both: prefer nested 'params', fall back to extracting plan fields
+    # from the top-level args.
+    params = args.get('params')
+    if not params or not isinstance(params, dict) or not any(params.values()):
+        # Params missing or empty — extract plan fields from top-level args
+        _PLAN_FIELDS = ('session', 'message', 'model', 'mode', 'tools',
+                        'attachments', 'plan_id', 'current_state', 'status',
+                        'current_model', 'current_mode', 'current_tools',
+                        'attachment_confirmed', 'steps')
+        params = {k: args[k] for k in _PLAN_FIELDS if k in args}
+    return err or handle_plan(args['platform'], args['action'], params, rc)
 
 def _h_send(args, rc):
     err = _validate_required(args, 'message')

--- a/tools/plan.py
+++ b/tools/plan.py
@@ -146,7 +146,11 @@ def handle_plan(platform: str, action: str, params: Dict,
 
 def _create_plan(platform: str, params: Dict,
                  redis_client) -> Dict[str, Any]:
-    """Create an execution plan. All fields required — no defaults.
+    """Create an execution plan.
+
+    For fresh sessions (session="new"): all fields required — no defaults.
+    For follow-ups (session=URL): only session + message required.
+      Model/mode/tools/attachments are optional (inherited from original session).
 
     Does NOT set audit_passed. Caller must run audit before send.
     """
@@ -170,7 +174,8 @@ def _create_plan(platform: str, params: Dict,
         }
 
     # Validate required fields
-    missing = []
+    # Follow-up sessions (URL) only need session + message.
+    # Fresh sessions ("new") need everything.
     session = params.get('session')
     message = params.get('message')
     model = params.get('model')
@@ -178,31 +183,58 @@ def _create_plan(platform: str, params: Dict,
     tools = params.get('tools')
     attachments = params.get('attachments')
 
+    is_followup = session and session != 'new' and session.startswith('http')
+
+    missing = []
     if not session:
         missing.append('session ("new" or URL)')
     if not message:
         missing.append('message')
-    if not model:
-        missing.append('model')
-    if not mode:
-        missing.append('mode')
-    if tools is None:
-        missing.append('tools (list or "none")')
-    if attachments is None:
-        missing.append('attachments (list or [])')
+
+    if not is_followup:
+        # Fresh sessions require all fields
+        if not model:
+            missing.append('model')
+        if not mode:
+            missing.append('mode')
+        if tools is None:
+            missing.append('tools (list or "none")')
+        if attachments is None:
+            missing.append('attachments (list or [])')
 
     if missing:
+        required_fields = {"session": '"new" or existing URL', "message": "Message text"}
+        if not is_followup:
+            required_fields.update({
+                "model": 'Model name or "N/A"',
+                "mode": "Mode name",
+                "tools": 'List or "none"',
+                "attachments": "List of file paths or []",
+            })
         return {"success": False, "error": "Missing required fields: " + ", ".join(missing),
-                "required_fields": {
-                    "session": '"new" or existing URL', "message": "Message text",
-                    "model": 'Model name or "N/A"', "mode": "Mode name",
-                    "tools": 'List or "none"', "attachments": "List of file paths or []",
-                }}
+                "required_fields": required_fields}
 
-    # Build attachment list: identity files + user files → consolidated
+    # Default optional fields for follow-ups
+    if is_followup:
+        model = model or 'inherited'
+        mode = mode or 'inherited'
+        if tools is None:
+            tools = 'none'
+        if attachments is None:
+            attachments = []
+
+    # Build attachment list:
+    # Follow-ups: NO identity files. Only user-provided attachments.
+    # Fresh sessions: identity files + user files → consolidated.
     attachments_list = [] if attachments == "none" else list(attachments) if attachments else []
-    all_files = _prepend_identity_files(attachments_list, platform)
-    identity_added = [f for f in all_files if f not in attachments_list]
+
+    if is_followup:
+        # Follow-ups: use attachments as-is (no identity prepend)
+        all_files = attachments_list
+        identity_added = []
+    else:
+        all_files = _prepend_identity_files(attachments_list, platform)
+        identity_added = [f for f in all_files if f not in attachments_list]
 
     consolidated_path = None
     if len(all_files) > 1:
@@ -218,6 +250,7 @@ def _create_plan(platform: str, params: Dict,
         'plan_id': plan_id,
         'platform': platform,
         'action': 'send_message',
+        'followup': is_followup,
         'session': session,
         'message': message,
         'attachment': final_attachment,  # Single file (consolidated)
@@ -256,21 +289,32 @@ def _create_plan(platform: str, params: Dict,
     for suffix in ['inspect', 'set_map', 'attach']:
         redis_client.delete(node_key(f"checkpoint:{platform}:{suffix}"))
 
-    result = {
-        "success": True,
-        "plan_id": plan_id,
-        "platform": platform,
-        "session": session,
-        "required_state": plan['required_state'],
-        "attachment": final_attachment,
-        "audit_passed": False,
-        "next_steps": [
+    if is_followup:
+        next_steps = [
+            "1. Navigate to session URL",
+            "2. Call taey_attach if follow-up attachments needed",
+            "3. Call taey_plan(action='audit') to verify",
+            "4. Call taey_send",
+        ]
+    else:
+        next_steps = [
             "1. Call taey_inspect to see current platform state",
             "2. Set model/mode if needed (taey_select_dropdown)",
             "3. Call taey_attach to upload the attachment",
             "4. Call taey_plan(action='audit') to verify everything matches",
             "5. Only then call taey_send",
-        ],
+        ]
+
+    result = {
+        "success": True,
+        "plan_id": plan_id,
+        "platform": platform,
+        "session": session,
+        "followup": is_followup,
+        "required_state": plan['required_state'],
+        "attachment": final_attachment,
+        "audit_passed": False,
+        "next_steps": next_steps,
     }
     if identity_added:
         result["identity_files_added"] = identity_added
@@ -553,11 +597,13 @@ def _audit_plan(platform: str, params: Dict,
     failures = []
 
     # Model check — exact match (case-insensitive)
+    # 'inherited' = follow-up session, model inherited from original — skip check.
     req_model = required.get('model', '')
-    model_check_source = model_source if req_model and req_model not in ('N/A', 'any', 'default') \
+    _MODEL_SKIP = ('N/A', 'any', 'default', 'inherited')
+    model_check_source = model_source if req_model and req_model not in _MODEL_SKIP \
         else 'not_required'
 
-    if req_model and req_model not in ('N/A', 'any', 'default'):
+    if req_model and req_model not in _MODEL_SKIP:
         if not actual_model:
             failures.append({
                 "field": "model",
@@ -579,10 +625,12 @@ def _audit_plan(platform: str, params: Dict,
             })
 
     # Mode check — exact match (case-insensitive)
+    # 'inherited' = follow-up session, mode inherited from original — skip check.
     req_mode = required.get('mode', '')
+    _MODE_SKIP = ('N/A', 'any', 'default', 'normal', 'inherited')
     mode_source = 'caller_reported'  # Mode is always caller-reported (no tree read yet)
 
-    if req_mode and req_mode not in ('N/A', 'any', 'default', 'normal'):
+    if req_mode and req_mode not in _MODE_SKIP:
         if not caller_mode:
             failures.append({
                 "field": "mode",


### PR DESCRIPTION
## Summary

Adds follow-up capability to the consultation system. Existing sessions can now receive follow-up messages by URL without re-sending identity files or re-selecting model/mode.

## Changes

### consultation.py
- **`--session-url` flag**: Navigate to existing session URL for follow-ups
- **Follow-up path**: Skips identity file prepend (no KERNEL/IDENTITY auto-attach), skips model/mode selection (inherited from original session)
- **Optional attachments**: `--attach` works for follow-ups but without identity consolidation
- **URL tracking**: Uses session URL directly for Neo4j session tracking

### tools/plan.py
- **Follow-up detection**: When `session` is a URL (not "new"), only `session + message` required
- **Optional fields**: Model/mode/tools/attachments default to 'inherited' for follow-ups
- **Audit skip**: Model/mode checks skip for 'inherited' values (no verification needed)
- **Distinct workflows**: Different `next_steps` for follow-up vs fresh session plans

### server.py
- **MCP params fix**: Handles MCP clients that flatten `params` to top-level args instead of nested object
- Extracts plan fields from top-level args when nested `params` is empty

## Usage

```bash
# Follow-up on existing Perplexity session
python3 scripts/consultation.py --platform perplexity \
    --session-url "https://www.perplexity.ai/search/abc123" \
    --message "Can you elaborate on point 3?"

# Follow-up with attachment
python3 scripts/consultation.py --platform gemini \
    --session-url "https://gemini.google.com/app/abc123" \
    --attach extra_context.md \
    --message "Here is additional context"

# Async follow-up (fire and forget)
python3 scripts/consultation.py --platform perplexity \
    --session-url "https://www.perplexity.ai/search/abc123" \
    --message "Follow-up question" --async-send
```

Closes #63