### PR TITLE
fix: node ID mismatch — consultation/monitor/hook all use different Redis keys (#69)

### DIFF
--- a/monitor/central.py
+++ b/monitor/central.py
@@ -61,6 +61,15 @@ from core.input import press_key, clipboard_paste
 from core.platforms import TAB_SHORTCUTS, CHAT_PLATFORMS, BASE_URLS, URL_PATTERNS
 from storage.redis_pool import node_key, NODE_ID
 
+# Verify node ID matches expectations — mismatch breaks monitor notifications
+if NODE_ID and '-d' in NODE_ID and not os.environ.get('TAEY_NODE_ID'):
+    import warnings
+    warnings.warn(
+        f"monitor using auto-detected node ID '{NODE_ID}'. "
+        f"Set TAEY_NODE_ID in .env or environment to match MCP server.",
+        RuntimeWarning, stacklevel=1,
+    )
+
 # Redis
 try:
     import redis as _redis_mod

--- a/scripts/consultation.py
+++ b/scripts/consultation.py
@@ -176,7 +176,17 @@ from core.tree import find_elements, find_copy_buttons, find_menu_items
 from core.interact import atspi_click
 from tools.attach import handle_attach, _close_stale_file_dialogs
 from tools.plan import _prepend_identity_files, _consolidate_attachments
-from storage.redis_pool import get_client as get_redis, node_key
+from storage.redis_pool import get_client as get_redis, node_key, NODE_ID
+
+# Verify node ID matches expectations — mismatch breaks monitor notifications
+if NODE_ID and '-d' in NODE_ID and not os.environ.get('TAEY_NODE_ID'):
+    # Got a display-scoped ID without explicit TAEY_NODE_ID — likely mismatch
+    import warnings
+    warnings.warn(
+        f"consultation.py using auto-detected node ID '{NODE_ID}'. "
+        f"Set TAEY_NODE_ID in .env or environment to match MCP server.",
+        RuntimeWarning, stacklevel=1,
+    )
 
 try:
     from storage import neo4j_client

--- a/storage/redis_pool.py
+++ b/storage/redis_pool.py
@@ -41,17 +41,54 @@ def get_client() -> redis.Redis:
     return _client
 
 
-def _detect_node_id() -> str:
-    """TAEY_NODE_ID env > display-scoped auto-id > tmux session > hostname.
+def _load_env_file() -> dict:
+    """Try loading .env from project root. Returns dict of key=value pairs."""
+    # Walk up from this file (storage/redis_pool.py) to find project root
+    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    env_path = os.path.join(project_root, '.env')
+    result = {}
+    if os.path.exists(env_path):
+        try:
+            with open(env_path) as f:
+                for line in f:
+                    line = line.strip()
+                    if line and not line.startswith('#') and '=' in line:
+                        k, v = line.split('=', 1)
+                        result[k.strip()] = v.strip()
+        except Exception:
+            pass
+    return result
 
-    When DISPLAY is set (e.g. :5), generates a deterministic node ID
-    like 'taeys-hands-d5' to prevent collisions between MCP instances
-    on different displays. This replaces the old hostname fallback that
-    caused all instances on the same machine to share Redis keys.
+
+def _detect_node_id() -> str:
+    """TAEY_NODE_ID env > .env file > display-scoped auto-id > tmux session > hostname.
+
+    Priority order:
+      1. TAEY_NODE_ID environment variable (set by caller or .mcp.json)
+      2. TAEY_NODE_ID from .env file (standalone scripts may not have loaded it yet)
+      3. Display-scoped auto-id (taeys-hands-d{N}) for multi-instance collision prevention
+      4. tmux session name
+      5. hostname
+
+    The .env fallback (step 2) is critical for standalone scripts like
+    consultation.py and monitor/central.py that run outside the MCP server
+    process. Without it, they generate different node IDs than the MCP
+    server and PostToolUse hooks, breaking Redis key lookups.
     """
     explicit = os.environ.get('TAEY_NODE_ID')
     if explicit:
         return explicit
+
+    # Try loading from .env — standalone scripts may not have loaded it yet.
+    # This is the most common case for node ID mismatch: MCP server gets
+    # TAEY_NODE_ID from .mcp.json, but consultation.py/monitor don't.
+    env_vars = _load_env_file()
+    env_node_id = env_vars.get('TAEY_NODE_ID')
+    if env_node_id:
+        # Also set it in the environment so downstream code sees it
+        os.environ['TAEY_NODE_ID'] = env_node_id
+        return env_node_id
+
     # Auto-scope by DISPLAY if available — prevents multi-instance collision
     display = os.environ.get('DISPLAY', '')
     if display:
@@ -103,6 +140,7 @@ def _find_ancestor_tty() -> str:
 
 _NODE_ID = _detect_node_id()
 NODE_ID = _NODE_ID
+logger.info("Redis node ID: %s", _NODE_ID)
 
 
 def node_key(suffix: str) -> str:


### PR DESCRIPTION
## Problem

All consultation monitor notifications are broken. Three components use three different Redis node IDs:

| Component | Node ID | Source |
|-----------|---------|--------|
| consultation.py | `taeys-hands-d0` | DISPLAY=:0 auto-detect |
| monitor/central.py | `mira` | hostname fallback |
| PostToolUse hook | `taeys-hands` | .env file |

Sessions register under `taey:taeys-hands-d0:active_session:*`, monitor scans for `taey:mira:*`, hook drains `taey:taeys-hands:notifications`. Nothing connects.

## Root Cause

Standalone scripts (consultation.py, monitor/central.py) run outside the MCP server process. They don't inherit `TAEY_NODE_ID` from `.mcp.json` env block. `_detect_node_id()` in redis_pool.py falls through to display-scoped auto-IDs or hostname, which don't match.

## Fix

### storage/redis_pool.py
`_detect_node_id()` now tries loading `TAEY_NODE_ID` from `.env` as priority 2:

1. `TAEY_NODE_ID` environment variable (set by caller or .mcp.json)
2. **NEW**: `TAEY_NODE_ID` from `.env` file (standalone scripts)
3. Display-scoped auto-id (`taeys-hands-d{N}`)
4. tmux session name
5. hostname

Also sets the env var when loading from .env, so downstream code sees it.

### consultation.py + monitor/central.py
Runtime warning when a display-scoped ID is used without explicit `TAEY_NODE_ID` — helps catch misconfiguration early.

Closes #69