### PR TITLE
fix: ChatGPT fence_after cuts off model_selector and input area (#73)

### DIFF
--- a/platforms/chatgpt.yaml
+++ b/platforms/chatgpt.yaml
@@ -234,11 +234,11 @@ sidebar_nav:
   - { name: "Your chats", role: heading }
 
 # ─── Sidebar Fence ────────────────────────────────────────────────
-# When this element is encountered during traversal, it is collected but
-# all remaining siblings in the parent are skipped. Excludes sidebar history.
-fence_after:
-  - { name: "New project", role: push button }
-  - { name: "Your chats", role: push button }
+# Disabled — see comment below.
+# EMPTY: ChatGPT model_selector and input area appear AFTER sidebar
+# elements in the AT-SPI tree. Fencing at "Your chats" cuts them off.
+# Sidebar noise is handled by element_filter.exclude instead.
+fence_after: []
 
 # ─── Validation Expectations ───────────────────────────────────────
 # Post-action verification: what the AT-SPI tree should look like after each action.


### PR DESCRIPTION
## Problem

ChatGPT `fence_after` fences at `Your chats` push button. The AT-SPI tree has `Model selector`, input area, and attach button AFTER this element — all fenced out.

```
push button: 'Your chats'         ← FENCE (stops sibling traversal)
  heading: 'Your chats'
  push button: 'Jesse LaRose...'
push button: 'Model selector'    ← FENCED OUT
entry: (input area)              ← FENCED OUT
```

### Impact
- Model/mode selection completely broken on ChatGPT
- Input area not found
- Attach button not found
- consultation.py fails or sends with wrong model

## Fix

Set `fence_after: []` for ChatGPT. Sidebar noise (history items) is already handled by `element_filter.exclude` — headings, landmarks, separators excluded by role.

This unblocks model selection, mode selection, input field discovery, and file attachment on ChatGPT.

Closes #73