### PR TITLE
fix: Claude model_selector — match plain model names without Extended suffix (#71)

### DIFF
--- a/platforms/claude.yaml
+++ b/platforms/claude.yaml
@@ -102,7 +102,7 @@ element_map:
     name_contains: ["Add files", "Add content"]
     role_contains: item
   model_selector:
-    name_contains: ["Opus 4.6 Extended", "Sonnet 4.6 Extended", "Sonnet 4.6", "Haiku 4.5"]
+    name_contains: ["Opus 4.6", "Sonnet 4.6", "Haiku 4.5"]
     role: push button
   # Model dropdown items
   model_opus:


### PR DESCRIPTION
## Problem

Claude `model_selector` `name_contains` had `"Opus 4.6 Extended"` and `"Sonnet 4.6 Extended"` but the button is just `"Opus 4.6"` when Extended Thinking is OFF. Model selector not found → mode selection fails.

## Fix

Simplified to `["Opus 4.6", "Sonnet 4.6", "Haiku 4.5"]`. Since `name_contains` does substring matching, `"Opus 4.6"` matches both `"Opus 4.6"` (plain) and `"Opus 4.6 Extended"`.

One-line YAML change.

Closes #71