### PR TITLE
Fix consultation mode selection flow

### DIFF
--- a/core/mode_select.py
+++ b/core/mode_select.py
@@ -382,6 +382,26 @@ def _click_element(element: Dict, platform: str) -> bool:
         return atspi_click(element)
 
 
+def _is_selected_item(item: Dict) -> bool:
+    """Check whether a menu item is already active before clicking it."""
+    states = {str(s).lower() for s in item.get('states', [])}
+    if 'checked' in states or 'selected' in states:
+        return True
+
+    obj = item.get('atspi_obj')
+    if not obj:
+        return False
+
+    try:
+        state_set = obj.get_state_set()
+        return (
+            state_set.contains(atspi.Atspi.StateType.CHECKED) or
+            state_set.contains(atspi.Atspi.StateType.SELECTED)
+        )
+    except Exception:
+        return False
+
+
 def _match_and_click(items: list, mode_key: str, platform: str) -> Dict:
     """Find matching item by name and click it."""
     from core.interact import atspi_click
@@ -415,6 +435,18 @@ def _match_and_click(items: list, mode_key: str, platform: str) -> Dict:
         for term in search_terms:
             if term in item_name or item_name.startswith(term):
                 logger.info(f"[{platform}] Menu match: '{item.get('name')}' for mode '{mode_key}'")
+
+                if _is_selected_item(item):
+                    logger.info(
+                        f"[{platform}] Item '{item.get('name')}' already selected; skipping click"
+                    )
+                    return {
+                        'success': True,
+                        'selected_mode': mode_key,
+                        'selected_item': item.get('name', ''),
+                        'platform': platform,
+                        'method': 'already_selected',
+                    }
 
                 clicked = False
                 if item.get('atspi_obj'):

--- a/core/tree.py
+++ b/core/tree.py
@@ -228,15 +228,24 @@ def find_menu_items(firefox, platform_doc=None) -> List[Dict]:
         if not (name and role in _ITEM_ROLES):
             return None
         try:
-            if require_showing and not child.get_state_set().contains(Atspi.StateType.SHOWING):
+            state_set = child.get_state_set()
+            if require_showing and not state_set.contains(Atspi.StateType.SHOWING):
                 return None
             comp = child.get_component_iface()
             if comp:
                 ext = comp.get_extents(Atspi.CoordType.SCREEN)
                 if ext.width > 0 and ext.height > 0:
-                    return {'name': name, 'role': role,
-                            'x': ext.x + ext.width // 2, 'y': ext.y + ext.height // 2,
-                            'atspi_obj': child}
+                    item = {
+                        'name': name,
+                        'role': role,
+                        'x': ext.x + ext.width // 2,
+                        'y': ext.y + ext.height // 2,
+                        'atspi_obj': child,
+                    }
+                    states = [s.value_nick for s in IMPORTANT_STATES if state_set.contains(s)]
+                    if states:
+                        item['states'] = states
+                    return item
         except Exception:
             pass
         return None
@@ -245,18 +254,32 @@ def find_menu_items(firefox, platform_doc=None) -> List[Dict]:
                  require_item_showing=False, containers=None):
         if containers is None:
             containers = _STRICT | _LOOSE
-        found = []
 
-        def search(obj, depth=0):
-            nonlocal found
-            if depth > max_depth or found:
-                return
-            try:
-                role = obj.get_role_name() or ''
-                if role == 'menu bar':
-                    return
-                if role in containers:
-                    if not require_showing or _is_showing(obj):
+        def dedupe(items):
+            merged = []
+            seen = set()
+            for item in items:
+                key = (item.get('name', ''), item.get('role', ''))
+                if key in seen:
+                    continue
+                seen.add(key)
+                merged.append(item)
+            return merged
+
+        current_level = [scope]
+        depth = 0
+
+        while current_level and depth <= max_depth:
+            next_level = []
+            level_items = []
+
+            for obj in current_level:
+                try:
+                    role = obj.get_role_name() or ''
+                    if role == 'menu bar':
+                        continue
+
+                    if role in containers and (not require_showing or _is_showing(obj)):
                         items = []
                         for i in range(min(obj.get_child_count(), 30)):
                             child = obj.get_child_at_index(i)
@@ -265,17 +288,22 @@ def find_menu_items(firefox, platform_doc=None) -> List[Dict]:
                                 if item:
                                     items.append(item)
                         if items:
-                            found = items
-                            return
-                for i in range(min(obj.get_child_count(), 30)):
-                    child = obj.get_child_at_index(i)
-                    if child:
-                        search(child, depth + 1)
-            except Exception:
-                pass
+                            level_items.extend(items)
 
-        search(scope)
-        return found
+                    for i in range(min(obj.get_child_count(), 30)):
+                        child = obj.get_child_at_index(i)
+                        if child:
+                            next_level.append(child)
+                except Exception:
+                    pass
+
+            if level_items:
+                return dedupe(level_items)
+
+            current_level = next_level
+            depth += 1
+
+        return []
 
     def _sorted(items):
         items.sort(key=lambda x: x['y'])

--- a/scripts/consultation.py
+++ b/scripts/consultation.py
@@ -223,121 +223,12 @@ logging.basicConfig(
 logger = logging.getLogger('consultation')
 
 
-# ---- Mode selection via subprocess worker ----
-# consultation.py imports Atspi after setup_env() sets DBUS_SESSION_BUS_ADDRESS
-# to the AT-SPI accessibility bus (/tmp/a11y_bus_:N). This is NOT the same
-# bus that dbus-run-session uses to run Firefox. Atspi.get_desktop(0) connects
-# at first call and caches the connection for the lifetime of the process.
-#
-# React portal dropdowns (Perplexity tools menu, etc.) register their nodes
-# on the dbus-run-session bus. A process connected to the a11y bus can find
-# the Firefox application object (which bridges both), but freshly-mounted
-# portal nodes are only visible on the session bus.
-#
-# Solution: launch select_mode_worker.py as a subprocess with
-# DBUS_SESSION_BUS_ADDRESS set from /tmp/dbus_addr_:N BEFORE any Atspi import.
-# The worker performs mode selection and reports JSON to stdout.
-
-def _read_file_stripped(path: str) -> str:
-    """Read a file and return its stripped content, or empty string."""
-    try:
-        with open(path) as f:
-            return f.read().strip()
-    except FileNotFoundError:
-        return ''
-
-
 def _select_mode_via_worker(platform: str, mode: str = None, model: str = None,
                              display: str = None) -> dict:
-    """Run mode selection in a subprocess with the correct dbus session bus.
-
-    This bypasses the AT-SPI bus problem: the worker process starts with
-    DBUS_SESSION_BUS_ADDRESS from /tmp/dbus_addr_:N (the dbus-run-session bus),
-    NOT the a11y bus. This lets Atspi.get_desktop(0) connect to the same
-    registry that Firefox is registered on, making React portal nodes visible.
-
-    Falls back to in-process select_mode_model() if the dbus_addr file is
-    missing (non-Mira environments, or displays launched differently).
-    """
-    disp = display or os.environ.get('DISPLAY', '')
-
-    # Read the dbus-run-session bus address (written by Firefox launch script)
-    dbus_addr_file = f'/tmp/dbus_addr_{disp}'
-    session_bus = _read_file_stripped(dbus_addr_file)
-
-    if not session_bus:
-        logger.warning(
-            f"No dbus_addr file at {dbus_addr_file} — falling back to in-process "
-            f"mode selection (may fail for React portal dropdowns on Perplexity)"
-        )
-        return _select_mode_inprocess(platform, mode, model)
-
-    # Read the a11y bus for AT_SPI_BUS_ADDRESS
-    a11y_bus = _read_file_stripped(f'/tmp/a11y_bus_{disp}')
-
-    # Read Firefox PID for display filtering
-    firefox_pid_str = _read_file_stripped(f'/tmp/firefox_pid_{disp}')
-    firefox_pid = int(firefox_pid_str) if firefox_pid_str.isdigit() else None
-
-    worker_script = os.path.join(_SCRIPT_DIR, 'select_mode_worker.py')
-    if not os.path.isfile(worker_script):
-        logger.error(f"select_mode_worker.py not found at {worker_script}")
-        return _select_mode_inprocess(platform, mode, model)
-
-    cmd = [sys.executable, worker_script, '--platform', platform]
-    if mode:
-        cmd += ['--mode', mode]
-    if model:
-        cmd += ['--model', model]
-    if firefox_pid:
-        cmd += ['--pid', str(firefox_pid)]
-
-    env = os.environ.copy()
-    env['DBUS_SESSION_BUS_ADDRESS'] = session_bus
-    if a11y_bus:
-        env['AT_SPI_BUS_ADDRESS'] = a11y_bus
-    env['DISPLAY'] = disp
-    env['GTK_USE_PORTAL'] = '0'
-    # Forward PYTHONPATH so worker finds project modules
-    env.setdefault('PYTHONPATH', _ROOT)
-    if _ROOT not in env.get('PYTHONPATH', ''):
-        env['PYTHONPATH'] = f"{_ROOT}:{env['PYTHONPATH']}"
-
-    logger.info(
-        f"Launching select_mode_worker: platform={platform} mode={mode} model={model} "
-        f"display={disp} dbus={session_bus[:40]}..."
-    )
-
-    try:
-        proc = subprocess.run(
-            cmd,
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        # Worker logs go to stderr — forward to our logger
-        if proc.stderr:
-            for line in proc.stderr.strip().splitlines():
-                logger.info(f"[worker] {line}")
-
-        stdout = proc.stdout.strip()
-        if not stdout:
-            return {
-                'success': False,
-                'error': f'select_mode_worker produced no output (rc={proc.returncode})',
-            }
-
-        result = json.loads(stdout)
-        logger.info(f"Worker result: {result}")
-        return result
-
-    except subprocess.TimeoutExpired:
-        return {'success': False, 'error': 'select_mode_worker timed out after 30s'}
-    except json.JSONDecodeError as e:
-        return {'success': False, 'error': f'Worker output not valid JSON: {e} / stdout={proc.stdout[:200]}'}
-    except Exception as e:
-        return {'success': False, 'error': f'Worker launch failed: {e}'}
+    """Compatibility wrapper: mode selection now runs in-process."""
+    if display and display != os.environ.get('DISPLAY'):
+        logger.info("Ignoring explicit display override for in-process mode selection: %s", display)
+    return _select_mode_inprocess(platform, mode, model)
 
 
 def _select_mode_inprocess(platform: str, mode: str = None, model: str = None) -> dict:
@@ -936,25 +827,11 @@ def main():
             result['attachment'] = pkg_path
 
     # ── Step 3: Model/mode selection (skip for follow-ups) ──────────────────
-    # For platforms where mode selection requires clicking a React portal
-    # dropdown (Perplexity tools menu), we MUST use the subprocess worker
-    # so the AT-SPI connection is made on the correct dbus session bus.
     if is_followup and not args.model and not args.mode:
         logger.info("Step 3: Model/mode selection skipped (follow-up)")
     elif args.model or args.mode:
         logger.info(f"Step 3: Selecting model={args.model} mode={args.mode}")
-        disp = os.environ.get('DISPLAY', '')
-        dbus_addr_file = f'/tmp/dbus_addr_{disp}'
-        use_worker = os.path.isfile(dbus_addr_file)
-
-        if use_worker:
-            logger.info(f"Step 3: Using subprocess worker (dbus_addr found: {dbus_addr_file})")
-            sel_result = _select_mode_via_worker(
-                platform, mode=args.mode, model=args.model, display=disp
-            )
-        else:
-            logger.info("Step 3: Using in-process mode selection (no dbus_addr file)")
-            sel_result = _select_mode_inprocess(platform, mode=args.mode, model=args.model)
+        sel_result = _select_mode_inprocess(platform, mode=args.mode, model=args.model)
 
         if sel_result.get('success'):
             logger.info(f"Mode/model selected: {sel_result.get('selected_mode', sel_result.get('matched', '?'))}")

--- a/tests/test_mode_select.py
+++ b/tests/test_mode_select.py
@@ -92,3 +92,27 @@ def test_element_map_coverage():
         em = config.get('element_map', {})
         for key in required_keys:
             assert key in em, f"{platform} missing element_map.{key}"
+
+
+def test_match_and_click_skips_click_for_already_selected(monkeypatch):
+    """Already-selected menu items should not be clicked again."""
+    from core.mode_select import _match_and_click
+
+    clicked = {'value': False}
+
+    def fail_click(_item):
+        clicked['value'] = True
+        raise AssertionError("click should not be attempted for already-selected item")
+
+    monkeypatch.setattr('core.interact.atspi_click', fail_click)
+
+    result = _match_and_click(
+        [{'name': 'Deep Research', 'role': 'check menu item', 'states': ['checked']}],
+        'deep_research',
+        'perplexity',
+    )
+
+    assert result.get('success') is True
+    assert result.get('method') == 'already_selected'
+    assert result.get('selected_item') == 'Deep Research'
+    assert clicked['value'] is False

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,0 +1,83 @@
+"""Focused tests for menu-item collection."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class _FakeExtents:
+    def __init__(self, x=10, y=10, width=20, height=20):
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+
+
+class _FakeComponent:
+    def __init__(self, extents=None):
+        self._extents = extents or _FakeExtents()
+
+    def get_extents(self, _coord_type):
+        return self._extents
+
+
+class _FakeStateSet:
+    def __init__(self, states):
+        self._states = set(states)
+
+    def contains(self, state):
+        return state in self._states
+
+
+class _FakeNode:
+    def __init__(self, role, name='', children=None, states=None, y=10):
+        self._role = role
+        self._name = name
+        self._children = children or []
+        self._state_set = _FakeStateSet(states or set())
+        self._component = _FakeComponent(_FakeExtents(y=y))
+
+    def get_role_name(self):
+        return self._role
+
+    def get_name(self):
+        return self._name
+
+    def get_state_set(self):
+        return self._state_set
+
+    def get_component_iface(self):
+        return self._component
+
+    def get_child_count(self):
+        return len(self._children)
+
+    def get_child_at_index(self, idx):
+        return self._children[idx]
+
+
+def test_find_menu_items_collects_sibling_containers_and_dedupes():
+    from core.tree import Atspi, find_menu_items
+
+    showing = {Atspi.StateType.SHOWING}
+    first_panel = _FakeNode(
+        'panel',
+        children=[_FakeNode('option', 'Deep Research', states=showing, y=20)],
+        states=showing,
+        y=10,
+    )
+    second_panel = _FakeNode(
+        'panel',
+        children=[
+            _FakeNode('option', 'Deep Research', states=showing, y=30),
+            _FakeNode('option', 'Normal', states=showing, y=40),
+        ],
+        states=showing,
+        y=15,
+    )
+    root = _FakeNode('document frame', children=[first_panel, second_panel], states=showing)
+
+    items = find_menu_items(None, root)
+
+    assert [item['name'] for item in items] == ['Deep Research', 'Normal']


### PR DESCRIPTION
## Summary
- remove consultation Step 3 subprocess mode-selection routing and keep selection in-process
- skip clicking menu items that are already checked/selected to avoid Perplexity toggle-off behavior
- make menu-item collection scan sibling containers breadth-first and dedupe split dropdown items
- add focused regression coverage for selected-state skipping and sibling container collection

## Verification
- `python3 -m py_compile scripts/consultation.py core/mode_select.py core/tree.py`
- `pytest -q tests/test_mode_select.py -k already_selected`
- `pytest -q tests/test_tree.py`

## Notes
- the broader `tests/test_mode_select.py` file already has pre-existing failures because it imports `_load_config`, which is not exported by `core.mode_select`; this PR does not change that behavior.