### PR TITLE
fix: unblock monitor completion when send button lookup fails

### DIFF
--- a/monitor/central.py
+++ b/monitor/central.py
@@ -4,8 +4,9 @@
 Completion detection:
   1. Poll every 2s for stop-button visibility, send-button readiness, and content hash
   2. Persist sticky ever-seen-stop flag per monitor session in Redis
-  3. COMPLETE when stop was seen and is now gone while send is ready
-  4. Fallback COMPLETE when content hash is stable for 2 ticks and send is ready
+  3. PRIMARY COMPLETE when stop was seen and is now gone
+  4. ENHANCED confidence when send is also ready at primary completion time
+  5. Fallback COMPLETE when content hash is stable for 2 ticks and send is ready
 
 URL navigation: verifies session URL matches current tab, navigates if mismatched.
 NO fixed coordinates. Stop button found by AT-SPI name matching.
@@ -257,8 +258,12 @@ class CentralMonitor:
             _log(f"[{platform}/{monitor_id}] stop=YES send={'YES' if send_visible else 'NO'} ({elapsed}s)")
             return False
 
-        if ever_seen_stop and send_visible:
-            _log(f"[{platform}/{monitor_id}] stop=NO send=YES ever_seen=YES → COMPLETE ({elapsed}s)")
+        if ever_seen_stop:
+            confidence = "high" if send_visible else "normal"
+            _log(
+                f"[{platform}/{monitor_id}] stop=NO send={'YES' if send_visible else 'NO'} "
+                f"ever_seen=YES → COMPLETE confidence={confidence} ({elapsed}s)"
+            )
             self._notify(session, "response_complete", "stop_button")
             return True
 

--- a/tests/test_monitor_central.py
+++ b/tests/test_monitor_central.py
@@ -1,0 +1,37 @@
+from unittest.mock import patch
+
+from monitor.central import CentralMonitor
+
+
+def test_detect_completion_allows_primary_gate_without_send_visible(mock_redis):
+    with patch.object(CentralMonitor, "_connect_redis", return_value=mock_redis):
+        monitor = CentralMonitor()
+
+    session = {
+        "platform": "chatgpt",
+        "monitor_id": "mon-123",
+        "started_ts": 0,
+        "timeout": 7200,
+    }
+
+    with patch.object(monitor, "_notify") as notify:
+        generating = monitor._detect_completion(
+            session,
+            {
+                "stop_found": True,
+                "send_visible": False,
+                "content_hash": "hash-1",
+            },
+        )
+        completed = monitor._detect_completion(
+            session,
+            {
+                "stop_found": False,
+                "send_visible": False,
+                "content_hash": "hash-2",
+            },
+        )
+
+    assert generating is False
+    assert completed is True
+    notify.assert_called_once_with(session, "response_complete", "stop_button")


### PR DESCRIPTION
## Summary
- make the primary completion gate depend on sticky stop visibility only
- keep send visibility as an optional confidence signal in monitor logs
- add a regression test covering completion when stop disappears but send visibility is false

## Testing
- pytest -q tests/test_monitor_central.py