### PR TITLE
Fix consultation monitor node ID mismatch

### DIFF
--- a/scripts/consultation.py
+++ b/scripts/consultation.py
@@ -54,6 +54,10 @@ import sys
 import time
 from datetime import datetime
 
+# consultation.py mutates DISPLAY per platform; pin the Redis node ID first
+# so monitor session keys stay aligned with the central monitor namespace.
+os.environ["TAEY_NODE_ID"] = "taeys-hands"
+
 
 # ---- Load .env FIRST (before any project imports or setup) ----
 # Standalone scripts don't inherit env from .mcp.json.


### PR DESCRIPTION
## Summary
- pin `TAEY_NODE_ID` to `taeys-hands` at the top of `scripts/consultation.py`
- ensure consultation monitor session registration stays under the base node namespace even when `DISPLAY` is rewritten per platform
- keep the fix scoped to the script to avoid touching high-blast-radius Redis key generation

## Verification
- `python3 -m py_compile scripts/consultation.py`
- verified with a Python import check that `DISPLAY=:3` plus `TAEY_NODE_ID=taeys-hands` yields `NODE_ID=taeys-hands` and keys like `taey:taeys-hands:active_session:test`
- confirmed the script only calls `node_key()` for the pending prompt and `register_monitor_session()` once for monitor registration

## Notes
- GitNexus impact analysis showed `node_key` is CRITICAL blast radius, so this PR avoids modifying it.
- The installed GitNexus CLI in this repo does not expose a `detect_changes` command; scope was checked with an isolated worktree plus a one-file staged diff instead.