### PR TITLE
Enforce universal consultation step order

### DIFF
--- a/platforms/perplexity.yaml
+++ b/platforms/perplexity.yaml
@@ -43,7 +43,6 @@ click_strategy: xdotool_first
 attach_method: keyboard_nav
 # How dropdowns work: AT-SPI enumerates menu items
 dropdown_method: atspi_enum
-step_order: [navigate, mode, message, attach, send]
 
 quirks:
   - sidebar: "Left sidebar OPEN (Search, Computer, New Thread, History, Discover, Spaces, Finance, More). Right sidebar always CLOSE."

--- a/scripts/consultation.py
+++ b/scripts/consultation.py
@@ -228,7 +228,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger('consultation')
 
-DEFAULT_STEP_ORDER = ['navigate', 'attach', 'mode', 'message', 'send']
+DEFAULT_STEP_ORDER = ['navigate', 'model', 'mode', 'attach', 'message', 'send']
 
 
 def _select_mode_via_worker(platform: str, mode: str = None, model: str = None,
@@ -253,28 +253,6 @@ def _select_mode_inprocess(platform: str, mode: str = None, model: str = None) -
         platform, mode=mode, model=model,
         doc=doc, firefox=ff,
     )
-
-
-def _get_step_order(platform: str) -> list[str]:
-    """Return the platform step order, falling back to the global default."""
-    config = get_platform_config(platform)
-    step_order = config.get('step_order')
-    if not step_order:
-        return list(DEFAULT_STEP_ORDER)
-
-    expected = set(DEFAULT_STEP_ORDER)
-    provided = list(step_order)
-    if (
-        set(provided) != expected
-        or len(provided) != len(DEFAULT_STEP_ORDER)
-        or provided[0] != 'navigate'
-    ):
-        logger.warning(
-            "Invalid step_order for %s: %s; using default %s",
-            platform, provided, DEFAULT_STEP_ORDER,
-        )
-        return list(DEFAULT_STEP_ORDER)
-    return provided
 
 
 # ---- Core functions (adapted from hmm_bot proven patterns) ----
@@ -765,6 +743,49 @@ def _verify_mode_selection(platform: str, target_mode: str, selection_result: di
     return {'verified': verified, 'method': verify_method, 'mode': target_mode}
 
 
+def _run_selection_step(platform: str, *, step_name: str, value: str,
+                        result: dict, timeout: int) -> tuple[bool, int]:
+    """Run and verify a single model or mode/tools selection step."""
+    logger.info("Selecting %s=%s", step_name, value)
+    sel_result = _select_mode_via_worker(
+        platform,
+        mode=value if step_name == 'mode' else None,
+        model=value if step_name == 'model' else None,
+        display=args.display,
+    )
+
+    if not sel_result.get('success'):
+        logger.error("%s selection FAILED: %s", step_name.title(), sel_result.get('error'))
+        logger.error("Available modes: %s", sel_result.get('available_modes', 'unknown'))
+        result['error'] = f"{step_name}_selection_failed: {sel_result.get('error')}"
+        result[f'{step_name}_selection'] = sel_result
+        return False, timeout
+
+    logger.info(
+        "%s selected: %s",
+        step_name.title(),
+        sel_result.get('selected_mode', sel_result.get('matched', '?')),
+    )
+    if sel_result.get('timeout'):
+        timeout = sel_result['timeout']
+        logger.info("Timeout adjusted to %ss for this %s", timeout, step_name)
+    result[f'{step_name}_selection'] = sel_result
+    time.sleep(1)
+
+    logger.info("Verifying %s in AT-SPI tree", step_name)
+    selection_verification = _verify_mode_selection(platform, value, sel_result)
+    if not selection_verification.get('verified'):
+        logger.error("HARD STOP: %s '%s' NOT verified in AT-SPI tree.", step_name, value)
+        result['error'] = f"{step_name}_not_verified: '{value}' not confirmed in AT-SPI tree"
+        result['verify_method'] = selection_verification.get('method')
+        return False, timeout
+
+    logger.info("%s verification PASSED (%s)",
+                step_name.title(), selection_verification.get('method'))
+    result[f'{step_name}_verified'] = selection_verification
+    return True, timeout
+
+
 def validate_attachment_visible(platform: str, file_path: str,
                                 attempts: int = 10, delay: float = 1.0) -> dict:
     """Confirm the uploaded file chip/indicator is visible in the AT-SPI tree."""
@@ -1091,129 +1112,103 @@ def main():
             pkg_path = _consolidate_attachments(all_files, platform)
         elif len(all_files) == 1:
             pkg_path = all_files[0]
-    step_order = _get_step_order(platform)
-    logger.info("Resolved step order for %s: %s", platform, " -> ".join(step_order))
+    logger.info("Resolved universal step order for %s: %s",
+                platform, " -> ".join(DEFAULT_STEP_ORDER))
 
-    mode_selected = False
+    logger.info("Step 2: Model selection")
+    if is_followup and not args.model:
+        logger.info("Step 2: Model selection skipped (follow-up)")
+    elif not args.model:
+        logger.info("Step 2: Model selection skipped (not requested)")
+    else:
+        ok, timeout = _run_selection_step(
+            platform,
+            step_name='model',
+            value=args.model,
+            result=result,
+            timeout=timeout,
+        )
+        if not ok:
+            print(json.dumps(result, indent=2))
+            sys.exit(1)
 
-    for index, step_name in enumerate(step_order[1:], start=2):
-        if step_name == 'attach':
-            if pkg_path and os.path.isfile(pkg_path):
-                logger.info("Step %s: Attaching %s", index, os.path.basename(pkg_path))
-                if not attach_file(platform, pkg_path):
-                    result['error'] = 'attach_failed'
-                    print(json.dumps(result, indent=2))
-                    sys.exit(1)
-                result['attachment'] = pkg_path
+    logger.info("Step 3: Mode/tools selection")
+    if is_followup and not args.mode:
+        logger.info("Step 3: Mode/tools selection skipped (follow-up)")
+    elif not args.mode:
+        logger.info("Step 3: Mode/tools selection skipped (not requested)")
+    else:
+        ok, timeout = _run_selection_step(
+            platform,
+            step_name='mode',
+            value=args.mode,
+            result=result,
+            timeout=timeout,
+        )
+        if not ok:
+            print(json.dumps(result, indent=2))
+            sys.exit(1)
 
-                logger.info("Step %sb: Validating uploaded file chip/indicator", index)
-                attachment_validation = validate_attachment_visible(platform, pkg_path)
-                result['attachment_validation'] = attachment_validation
-                if not attachment_validation.get('verified'):
-                    logger.error("HARD STOP: attached file not visible in AT-SPI tree after upload")
-                    result['error'] = 'attachment_not_verified'
-                    print(json.dumps(result, indent=2))
-                    sys.exit(1)
+    if pkg_path and os.path.isfile(pkg_path):
+        logger.info("Step 4: Attaching %s", os.path.basename(pkg_path))
+        if not attach_file(platform, pkg_path):
+            result['error'] = 'attach_failed'
+            print(json.dumps(result, indent=2))
+            sys.exit(1)
+        result['attachment'] = pkg_path
 
-                logger.info("Attachment verification PASSED (%s)",
-                            attachment_validation.get('method'))
+        logger.info("Step 4b: Validating uploaded file chip/indicator")
+        attachment_validation = validate_attachment_visible(platform, pkg_path)
+        result['attachment_validation'] = attachment_validation
+        if not attachment_validation.get('verified'):
+            logger.error("HARD STOP: attached file not visible in AT-SPI tree after upload")
+            result['error'] = 'attachment_not_verified'
+            print(json.dumps(result, indent=2))
+            sys.exit(1)
 
-                if platform == 'perplexity' and args.mode and mode_selected:
-                    target_mode = args.mode.replace('_', ' ').lower().strip()
-                    if 'deep research' in target_mode:
-                        logger.info("Step %sc: Re-check Perplexity Deep Research after attach", index)
-                        mode_verification = _verify_mode_selection(
-                            platform, args.mode, result.get('mode_selection', {})
-                        )
-                        if not mode_verification.get('verified'):
-                            logger.warning("Perplexity Deep Research no longer verified after attach; reselecting")
-                            sel_result = _select_mode_via_worker(
-                                platform,
-                                mode=args.mode,
-                                model=args.model,
-                                display=args.display,
-                            )
-                            if not sel_result.get('success'):
-                                result['error'] = f"mode_selection_failed: {sel_result.get('error')}"
-                                result['mode_selection'] = sel_result
-                                print(json.dumps(result, indent=2))
-                                sys.exit(1)
-                            result['mode_selection'] = sel_result
-                            time.sleep(1)
-                            mode_verification = _verify_mode_selection(platform, args.mode, sel_result)
-                            if not mode_verification.get('verified'):
-                                result['error'] = f"mode_not_verified: '{args.mode}' not confirmed after attach"
-                                result['verify_method'] = mode_verification.get('method')
-                                print(json.dumps(result, indent=2))
-                                sys.exit(1)
-                        result['mode_verified_after_attach'] = mode_verification
-            else:
-                logger.info("Step %s: No attachments to add (skipped)", index)
+        logger.info("Attachment verification PASSED (%s)",
+                    attachment_validation.get('method'))
 
-        elif step_name == 'mode':
-            if is_followup and not args.model and not args.mode:
-                logger.info("Step %s: Model/mode selection skipped (follow-up)", index)
-                continue
-            if not (args.model or args.mode):
-                logger.info("Step %s: Model/mode selection skipped (not requested)", index)
-                continue
-
-            logger.info("Step %s: Selecting model=%s mode=%s", index, args.model, args.mode)
-            sel_result = _select_mode_via_worker(
-                platform,
-                mode=args.mode,
-                model=args.model,
-                display=args.display,
-            )
-
-            if sel_result.get('success'):
-                logger.info(
-                    "Mode/model selected: %s",
-                    sel_result.get('selected_mode', sel_result.get('matched', '?')),
+        if platform == 'perplexity' and args.mode:
+            target_mode = args.mode.replace('_', ' ').lower().strip()
+            if 'deep research' in target_mode:
+                logger.info("Step 4c: Re-check Perplexity Deep Research after attach")
+                mode_verification = _verify_mode_selection(
+                    platform, args.mode, result.get('mode_selection', {})
                 )
-                if sel_result.get('timeout'):
-                    timeout = sel_result['timeout']
-                    logger.info("Timeout adjusted to %ss for this mode", timeout)
-                result['mode_selection'] = sel_result
-            else:
-                logger.error("Mode/model selection FAILED: %s", sel_result.get('error'))
-                logger.error("Available modes: %s", sel_result.get('available_modes', 'unknown'))
-                result['error'] = f"mode_selection_failed: {sel_result.get('error')}"
-                result['mode_selection'] = sel_result
-                print(json.dumps(result, indent=2))
-                sys.exit(1)
-            time.sleep(1)
+                if not mode_verification.get('verified'):
+                    logger.warning("Perplexity Deep Research no longer verified after attach; reselecting")
+                    ok, timeout = _run_selection_step(
+                        platform,
+                        step_name='mode',
+                        value=args.mode,
+                        result=result,
+                        timeout=timeout,
+                    )
+                    if not ok:
+                        print(json.dumps(result, indent=2))
+                        sys.exit(1)
+                    mode_verification = result.get('mode_verified', {})
+                    if not mode_verification.get('verified'):
+                        result['error'] = f"mode_not_verified: '{args.mode}' not confirmed after attach"
+                        result['verify_method'] = mode_verification.get('method')
+                        print(json.dumps(result, indent=2))
+                        sys.exit(1)
+                result['mode_verified_after_attach'] = mode_verification
+    else:
+        logger.info("Step 4: No attachments to add (skipped)")
 
-            logger.info("Step %sb: Verifying mode/model in AT-SPI tree", index)
-            target_mode = args.mode or args.model
-            mode_verification = _verify_mode_selection(
-                platform, target_mode, result.get('mode_selection', {})
-            )
-            if not mode_verification.get('verified'):
-                logger.error(f"HARD STOP: mode '{target_mode}' NOT verified in AT-SPI tree. "
-                             f"Will NOT send without verification.")
-                result['error'] = f"mode_not_verified: '{target_mode}' not confirmed in AT-SPI tree"
-                result['verify_method'] = mode_verification.get('method')
-                print(json.dumps(result, indent=2))
-                sys.exit(1)
+    logger.info("Step 5: Type prompt into input")
+    if not type_prompt(platform, message):
+        result['error'] = 'prompt_type_failed'
+        print(json.dumps(result, indent=2))
+        sys.exit(1)
 
-            logger.info("Mode verification PASSED (%s)", mode_verification.get('method'))
-            result['mode_verified'] = mode_verification
-            mode_selected = True
-
-        elif step_name == 'message':
-            logger.info("Step %s: Type prompt into input", index)
-            if not type_prompt(platform, message):
-                result['error'] = 'prompt_type_failed'
-                print(json.dumps(result, indent=2))
-                sys.exit(1)
-
-        elif step_name == 'send':
-            logger.info("Step %s: Send prompt", index)
-            if not submit_prompt(platform):
-                result['error'] = 'send_failed'
-                print(json.dumps(result, indent=2))
-                sys.exit(1)
+    logger.info("Step 6: Send prompt")
+    if not submit_prompt(platform):
+        result['error'] = 'send_failed'
+        print(json.dumps(result, indent=2))
+        sys.exit(1)
 
     # Step 6b: Register monitor session + Neo4j storage
     url = args.session_url


### PR DESCRIPTION
## Summary
- hard-code the consultation execution flow to navigate -> model -> mode/tools -> attach -> type -> send
- split model and mode/tools into separate orchestrated steps in consultation.py
- remove the Perplexity-specific step_order override from platform YAML

## Verification
- python3 -m py_compile scripts/consultation.py
- reviewed staged diff for scripts/consultation.py and platforms/perplexity.yaml
