### PR TITLE
Wire monitor auto-extraction after completion

### DIFF
--- a/monitor/central.py
+++ b/monitor/central.py
@@ -49,7 +49,9 @@ if os.path.exists(_env_path):
 DISPLAY = os.environ.get('DISPLAY', ':0')
 
 # Shared modules — only what workers-based monitoring needs
+from core.extractor import ExtractorRegistry
 from core.platforms import CHAT_PLATFORMS
+from core.storage_pipeline import StoragePipeline
 from storage.redis_pool import node_key, NODE_ID
 
 # Verify node ID matches expectations — mismatch breaks monitor notifications
@@ -325,6 +327,60 @@ class CentralMonitor:
                 _log(f"Redis notification error: {e}")
         else:
             _log(f"No Redis — notification for {session.get('monitor_id')} dropped")
+
+        if status == "response_complete":
+            self._extract_and_store(session)
+
+    def _extract_and_store(self, session: Dict):
+        """Best-effort extraction and storage after completion notification."""
+        platform = session.get('platform')
+        session_id = session.get('session_id')
+        monitor_id = session.get('monitor_id')
+
+        if not platform:
+            _log(f"[{monitor_id}] Extraction skipped: missing platform")
+            return
+
+        try:
+            from workers.manager import send_to_worker
+
+            extractor = ExtractorRegistry()
+            result = extractor.extract(
+                platform,
+                lambda cmd: send_to_worker(platform, cmd, timeout=120.0),
+            )
+            if not result:
+                _log(f"[{platform}/{monitor_id}] Extraction failed: empty worker result")
+                return
+
+            if result.get("error"):
+                _log(f"[{platform}/{monitor_id}] Extraction failed: {result['error']}")
+                return
+
+            content = result.get("content")
+            if not result.get("success") or not content:
+                _log(
+                    f"[{platform}/{monitor_id}] Extraction failed: "
+                    f"success={result.get('success', False)} content_present={bool(content)}"
+                )
+                return
+
+            content_hash = StoragePipeline().store(
+                platform,
+                content,
+                session_id,
+                monitor_id,
+                self.rc,
+            )
+            if content_hash:
+                _log(
+                    f"[{platform}/{monitor_id}] Extracted {len(content)} chars "
+                    f"from {platform}, stored as {content_hash}"
+                )
+            else:
+                _log(f"[{platform}/{monitor_id}] Extraction skipped: storage returned no content hash")
+        except Exception as e:
+            _log(f"[{platform}/{monitor_id}] Extraction failed: {e}")
 
     def run(self):
         """Main loop — poll workers for completion state every cycle."""

--- a/tests/test_monitor_central.py
+++ b/tests/test_monitor_central.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from monitor.central import CentralMonitor
 
@@ -35,3 +35,69 @@ def test_detect_completion_allows_primary_gate_without_send_visible(mock_redis):
     assert generating is False
     assert completed is True
     notify.assert_called_once_with(session, "response_complete", "stop_button")
+
+
+def test_notify_extracts_and_stores_after_response_complete(mock_redis):
+    with patch.object(CentralMonitor, "_connect_redis", return_value=mock_redis):
+        monitor = CentralMonitor()
+
+    session = {
+        "platform": "chatgpt",
+        "monitor_id": "mon-123",
+        "session_id": "sess-123",
+        "started_ts": 0,
+    }
+
+    extractor = MagicMock()
+    extractor.extract.return_value = {
+        "success": True,
+        "content": "hello world",
+    }
+    storage = MagicMock()
+    storage.store.return_value = "hash-123"
+
+    with patch("monitor.central.ExtractorRegistry", return_value=extractor), \
+         patch("monitor.central.StoragePipeline", return_value=storage), \
+         patch("workers.manager.send_to_worker") as send_to_worker:
+        monitor._notify(session, "response_complete", "stop_button")
+
+    extractor.extract.assert_called_once()
+    worker_fn = extractor.extract.call_args.args[1]
+    worker_fn({"cmd": "extract", "strategy": "response_last_copy"})
+    send_to_worker.assert_called_once_with(
+        "chatgpt",
+        {"cmd": "extract", "strategy": "response_last_copy"},
+        timeout=120.0,
+    )
+    storage.store.assert_called_once_with(
+        "chatgpt",
+        "hello world",
+        "sess-123",
+        "mon-123",
+        mock_redis,
+    )
+
+
+def test_notify_keeps_notification_when_extraction_fails(mock_redis):
+    with patch.object(CentralMonitor, "_connect_redis", return_value=mock_redis):
+        monitor = CentralMonitor()
+
+    session = {
+        "platform": "chatgpt",
+        "monitor_id": "mon-123",
+        "session_id": "sess-123",
+        "started_ts": 0,
+    }
+
+    rpush = MagicMock()
+    mock_redis.rpush = rpush
+
+    extractor = MagicMock()
+    extractor.extract.side_effect = RuntimeError("worker failed")
+
+    with patch("monitor.central.ExtractorRegistry", return_value=extractor), \
+         patch("monitor.central.StoragePipeline") as storage:
+        monitor._notify(session, "response_complete", "stop_button")
+
+    rpush.assert_called_once()
+    storage.assert_not_called()


### PR DESCRIPTION
## Summary
- wire `ExtractorRegistry` and `StoragePipeline` into `monitor/central.py` after `response_complete` notifications
- run extraction through `send_to_worker` on the platform worker and keep it best-effort so notifications still go through on failure
- add monitor tests for successful extraction/storage and extraction failure behavior

## Testing
- pytest -q tests/test_monitor_central.py