### PR TITLE
Fix storage pipeline session metadata

### DIFF
--- a/core/storage_pipeline.py
+++ b/core/storage_pipeline.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import uuid
+from datetime import datetime, timezone
 
 from neo4j import GraphDatabase
 
@@ -24,7 +25,7 @@ class StoragePipeline:
         except (TypeError, json.JSONDecodeError):
             return {}
 
-    def store(self, platform, content, session_id, monitor_id, redis_client):
+    def store(self, platform, content, session_id, monitor_id, redis_client, source="monitor"):
         if not content:
             return None
         pending = self._pending(platform, redis_client)
@@ -32,15 +33,20 @@ class StoragePipeline:
         message_id = str(uuid.uuid4())[:12]
         content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
         url = pending.get("session_url", "")
+        created_at = datetime.now(timezone.utc)
         with self.driver.session() as session:
             session.run(
                 """
                 MERGE (s:ChatSession {session_id: $session_id})
-                ON CREATE SET s.platform = $platform, s.url = $url, s.created_at = datetime()
-                SET s.last_activity = datetime()
+                ON CREATE SET
+                  s.platform = $platform,
+                  s.source = $source,
+                  s.url = $url,
+                  s.created_at = $created_at
+                SET s.last_activity = $created_at
                 CREATE (m:Message {
                   message_id: $message_id, role: 'assistant', content: $content,
-                  content_hash: $content_hash, monitor_id: $monitor_id, created_at: datetime()
+                  content_hash: $content_hash, monitor_id: $monitor_id, created_at: $created_at
                 })
                 MERGE (s)-[:HAS_MESSAGE]->(m)
                 WITH s
@@ -48,7 +54,9 @@ class StoragePipeline:
                 """,
                 session_id=session_id,
                 platform=platform,
+                source=source,
                 url=url,
+                created_at=created_at,
                 message_id=message_id,
                 content=content,
                 content_hash=content_hash,

--- a/monitor/central.py
+++ b/monitor/central.py
@@ -371,6 +371,7 @@ class CentralMonitor:
                 session_id,
                 monitor_id,
                 self.rc,
+                source="monitor",
             )
             if content_hash:
                 _log(


### PR DESCRIPTION
## Summary
- pass explicit `source` metadata through `StoragePipeline.store()`
- bind `platform`, `source`, and `created_at` into the Neo4j Cypher params
- update the monitor caller to mark stored assistant responses as coming from `monitor`

## Verification
- `python3 -m py_compile core/storage_pipeline.py monitor/central.py`
- verified committed scope only touches `core/storage_pipeline.py` and `monitor/central.py`
