### PR TITLE
Make auto-extract fully non-blocking

### DIFF
--- a/monitor/central.py
+++ b/monitor/central.py
@@ -27,6 +27,7 @@ Environment:
 import argparse
 import json
 import os
+import signal
 import sys
 import time
 from datetime import datetime
@@ -73,6 +74,15 @@ except ImportError:
 POLL_INTERVAL = 2.0
 STABLE_TICKS = 2
 DEFAULT_WORKER_TIMEOUT = 5.0
+EXTRACT_HARD_TIMEOUT_SEC = 5
+
+
+class ExtractTimeout(Exception):
+    """Raised when the hard extraction timeout fires."""
+
+
+def _timeout_handler(signum, frame):
+    raise ExtractTimeout()
 
 
 def _log(msg: str):
@@ -396,6 +406,12 @@ class CentralMonitor:
             return
 
         try:
+            old_handler = signal.signal(signal.SIGALRM, _timeout_handler)
+            signal.alarm(EXTRACT_HARD_TIMEOUT_SEC)
+        except Exception:
+            return
+
+        try:
             extractor = ExtractorRegistry()
             result = extractor.extract(
                 platform,
@@ -432,8 +448,16 @@ class CentralMonitor:
                 )
             else:
                 _log(f"[{platform}/{monitor_id}] Extraction skipped: storage returned no content hash")
+        except ExtractTimeout:
+            _log(
+                f"[{platform}/{monitor_id}] WARN: Extract timed out after "
+                f"{EXTRACT_HARD_TIMEOUT_SEC}s; skipping"
+            )
         except Exception as e:
-            _log(f"[{platform}/{monitor_id}] Extraction failed: {e}")
+            _log(f"[{platform}/{monitor_id}] WARN: Extract failed: {e}; skipping")
+        finally:
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, old_handler)
 
     def run(self):
         """Main loop — poll workers for completion state every cycle."""

--- a/tests/test_monitor_central.py
+++ b/tests/test_monitor_central.py
@@ -1,7 +1,7 @@
 import os
 from unittest.mock import MagicMock, patch
 
-from monitor.central import CentralMonitor
+from monitor.central import CentralMonitor, ExtractTimeout
 
 
 def test_detect_completion_allows_primary_gate_without_send_visible(mock_redis):
@@ -103,6 +103,55 @@ def test_notify_keeps_notification_when_extraction_fails(mock_redis):
         monitor._notify(session, "response_complete", "stop_button")
 
     rpush.assert_called_once()
+    storage.assert_not_called()
+
+
+def test_notify_keeps_notification_when_extraction_times_out(mock_redis):
+    with patch.object(CentralMonitor, "_connect_redis", return_value=mock_redis):
+        monitor = CentralMonitor()
+
+    session = {
+        "platform": "chatgpt",
+        "monitor_id": "mon-123",
+        "session_id": "sess-123",
+        "started_ts": 0,
+    }
+
+    rpush = MagicMock()
+    mock_redis.rpush = rpush
+
+    extractor = MagicMock()
+    extractor.extract.side_effect = ExtractTimeout()
+
+    with patch("monitor.central.ExtractorRegistry", return_value=extractor), \
+         patch("monitor.central.StoragePipeline") as storage:
+        monitor._notify(session, "response_complete", "stop_button")
+
+    rpush.assert_called_once()
+    storage.assert_not_called()
+
+
+def test_notify_keeps_notification_when_signal_setup_fails(mock_redis):
+    with patch.object(CentralMonitor, "_connect_redis", return_value=mock_redis):
+        monitor = CentralMonitor()
+
+    session = {
+        "platform": "chatgpt",
+        "monitor_id": "mon-123",
+        "session_id": "sess-123",
+        "started_ts": 0,
+    }
+
+    rpush = MagicMock()
+    mock_redis.rpush = rpush
+
+    with patch("monitor.central.signal.signal", side_effect=ValueError("no signals")), \
+         patch("monitor.central.ExtractorRegistry") as extractor, \
+         patch("monitor.central.StoragePipeline") as storage:
+        monitor._notify(session, "response_complete", "stop_button")
+
+    rpush.assert_called_once()
+    extractor.assert_not_called()
     storage.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- add a hard SIGALRM timeout around monitor auto-extract so a hung worker cannot stall the monitor loop
- keep extraction best-effort and leave notification delivery on the primary path
- add monitor tests for timeout and signal-setup failure cases

## Testing
- pytest -q tests/test_monitor_central.py