### PR TITLE
Fix Gemini Deep Research post-send scroll

### DIFF
--- a/scripts/consultation.py
+++ b/scripts/consultation.py
@@ -848,6 +848,8 @@ def _execute_post_send_action(platform: str, mode: str = None) -> bool:
         logger.error("post_send_action missing name_contains for %s/%s", platform, mode_key)
         return False
 
+    inp.press_key('ctrl+End')
+    time.sleep(1)
     inspect_result = send_to_worker(
         platform,
         {'cmd': 'inspect', 'scroll': 'bottom', 'fresh_session': False},


### PR DESCRIPTION
## Summary
- scroll to the bottom before searching for Gemini's post-send Start research button
- wait 1 second for the scroll to settle before inspecting controls

## Testing
- python3 -m py_compile scripts/consultation.py