### PR TITLE
Fix Gemini DR post-send crash

### DIFF
--- a/scripts/consultation.py
+++ b/scripts/consultation.py
@@ -176,13 +176,9 @@ sys.path.insert(0, _ROOT)
 
 # .env already loaded at top of file (before setup_env and all imports)
 
-# Clear _PLATFORM_DISPLAYS (populated at import time from .env)
 import gi
 gi.require_version('Atspi', '2.0')
 from gi.repository import Atspi
-
-from core.platforms import _PLATFORM_DISPLAYS
-_PLATFORM_DISPLAYS.clear()
 
 from core import atspi, input as inp, clipboard
 from core.config import get_platform_config, get_attach_method


### PR DESCRIPTION
## Summary
- preserve the platform-to-display mapping loaded by consultation startup
- stop clearing  before post-send worker IPC runs
- restore Gemini Deep Research post-send actions that depend on  resolving 

## Verification
- confirmed  and  resolve to 
- checked branch diff against  only changes 