### PR TITLE
fix: preserve falsey taey_plan MCP params

### DIFF
--- a/server.py
+++ b/server.py
@@ -246,13 +246,15 @@ def _h_plan(args, rc):
     # MCP clients may send params as nested object OR flatten fields to top level.
     # Accept both: prefer nested 'params', fall back to extracting plan fields
     # from the top-level args.
+    _PLAN_FIELDS = ('session', 'message', 'model', 'mode', 'tools',
+                    'attachments', 'plan_id', 'current_state', 'status',
+                    'current_model', 'current_mode', 'current_tools',
+                    'attachment_confirmed', 'steps')
     params = args.get('params')
-    if not params or not isinstance(params, dict) or not any(params.values()):
-        # Params missing or empty — extract plan fields from top-level args
-        _PLAN_FIELDS = ('session', 'message', 'model', 'mode', 'tools',
-                        'attachments', 'plan_id', 'current_state', 'status',
-                        'current_model', 'current_mode', 'current_tools',
-                        'attachment_confirmed', 'steps')
+    if params is not None and not isinstance(params, dict):
+        return {"error": "params must be an object"}
+    if params is None or not params:
+        # Params missing or an empty object — extract plan fields from top-level args
         params = {k: args[k] for k in _PLAN_FIELDS if k in args}
     return err or handle_plan(args['platform'], args['action'], params, rc)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -49,6 +49,23 @@ def test_send_message_requires_fields():
     assert "message" in result["error"]
 
 
+def test_taey_plan_preserves_nested_falsey_params():
+    redis_client = MagicMock()
+    with patch("server.handle_plan", return_value={"success": True}) as mock_handle_plan:
+        result = handle_tool(
+            "taey_plan",
+            {
+                "platform": "claude",
+                "action": "update",
+                "params": {"tools": []},
+            },
+            redis_client,
+        )
+
+    assert result["success"] is True
+    mock_handle_plan.assert_called_once_with("claude", "update", {"tools": []}, redis_client)
+
+
 def test_inject_notifications_empty(mock_redis):
     result = {"success": True}
     result = inject_notifications(result, mock_redis)


### PR DESCRIPTION
## Summary
- fix taey_plan MCP param normalization so nested params with falsey values like tools=[] are preserved
- only fall back to top-level plan fields when params is missing or an empty object
- add a regression test covering nested params={"tools": []}

## Verification
- pytest -q tests/test_server.py tests/test_tool_plan.py

## Notes
- GitNexus impact for _h_plan reported LOW risk with 0 direct callers and 0 affected processes
- Local GitNexus CLI in this environment does not expose detect_changes, so scope was verified via git diff before commit