### PR TITLE
Fix false Deep Research monitor completion

### DIFF
--- a/monitor/central.py
+++ b/monitor/central.py
@@ -295,6 +295,8 @@ class CentralMonitor:
             return
         self.rc.delete(
             self._monitor_key(monitor_id, "ever_seen_stop"),
+            self._monitor_key(monitor_id, "stop_visible"),
+            self._monitor_key(monitor_id, "stop_cycles"),
             self._monitor_key(monitor_id, "content_hash"),
             self._monitor_key(monitor_id, "content_stable_ticks"),
         )
@@ -303,6 +305,7 @@ class CentralMonitor:
         """Check session completion using sticky stop visibility and content stability."""
         platform = session['platform']
         monitor_id = session['monitor_id']
+        mode = (session.get('mode') or "").strip().lower()
         started_ts = session.get('started_ts', time.time())
         timeout = session.get('timeout', 7200)
         elapsed = int(time.time() - started_ts)
@@ -310,28 +313,59 @@ class CentralMonitor:
         send_visible = bool(worker_state.get('send_visible'))
         content_hash = worker_state.get('content_hash') or ""
         state_ttl = timeout
+        required_stop_cycles = 2 if mode in {"deep_research", "deep_think"} else 1
 
         ever_seen_key = self._monitor_key(monitor_id, "ever_seen_stop")
+        stop_visible_key = self._monitor_key(monitor_id, "stop_visible")
+        stop_cycles_key = self._monitor_key(monitor_id, "stop_cycles")
         hash_key = self._monitor_key(monitor_id, "content_hash")
         stable_key = self._monitor_key(monitor_id, "content_stable_ticks")
 
         ever_seen_stop = self.rc.get(ever_seen_key) == "1"
+        stop_was_visible = self.rc.get(stop_visible_key) == "1"
+        stop_cycles = int(self.rc.get(stop_cycles_key) or "0")
 
         if stop_found:
             self.rc.setex(ever_seen_key, state_ttl, "1")
+            self.rc.setex(stop_visible_key, state_ttl, "1")
             self.rc.setex(hash_key, state_ttl, content_hash)
             self.rc.setex(stable_key, state_ttl, "0")
-            _log(f"[{platform}/{monitor_id}] stop=YES send={'YES' if send_visible else 'NO'} ({elapsed}s)")
+            _log(
+                f"[{platform}/{monitor_id}] stop=YES send={'YES' if send_visible else 'NO'} "
+                f"mode={mode or 'default'} cycles={stop_cycles}/{required_stop_cycles} ({elapsed}s)"
+            )
+            return False
+
+        if ever_seen_stop and stop_was_visible:
+            stop_cycles += 1
+            self.rc.setex(stop_cycles_key, state_ttl, str(stop_cycles))
+            self.rc.setex(stop_visible_key, state_ttl, "0")
+
+            if stop_cycles >= required_stop_cycles:
+                confidence = "high" if send_visible else "normal"
+                _log(
+                    f"[{platform}/{monitor_id}] stop=NO send={'YES' if send_visible else 'NO'} "
+                    f"mode={mode or 'default'} cycles={stop_cycles}/{required_stop_cycles} "
+                    f"→ COMPLETE confidence={confidence} ({elapsed}s)"
+                )
+                self._notify(session, "response_complete", "stop_button")
+                return True
+
+            _log(
+                f"[{platform}/{monitor_id}] stop=NO send={'YES' if send_visible else 'NO'} "
+                f"mode={mode or 'default'} cycles={stop_cycles}/{required_stop_cycles} "
+                f"→ waiting for next stop cycle ({elapsed}s)"
+            )
             return False
 
         if ever_seen_stop:
+            self.rc.setex(stop_visible_key, state_ttl, "0")
             confidence = "high" if send_visible else "normal"
             _log(
                 f"[{platform}/{monitor_id}] stop=NO send={'YES' if send_visible else 'NO'} "
-                f"ever_seen=YES → COMPLETE confidence={confidence} ({elapsed}s)"
+                f"mode={mode or 'default'} cycles={stop_cycles}/{required_stop_cycles} "
+                f"ever_seen=YES no-transition confidence={confidence} ({elapsed}s)"
             )
-            self._notify(session, "response_complete", "stop_button")
-            return True
 
         if time.time() - started_ts > timeout:
             _log(f"[{platform}/{monitor_id}] Timeout after {timeout}s")
@@ -367,7 +401,8 @@ class CentralMonitor:
 
         _log(
             f"[{platform}/{monitor_id}] stop=NO send={'YES' if send_visible else 'NO'} "
-            f"ever_seen={'YES' if ever_seen_stop else 'NO'} stable_ticks={stable_ticks} ({elapsed}s)"
+            f"mode={mode or 'default'} ever_seen={'YES' if ever_seen_stop else 'NO'} "
+            f"cycles={stop_cycles}/{required_stop_cycles} stable_ticks={stable_ticks} ({elapsed}s)"
         )
         return False
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ def mock_redis():
     """Mock Redis client with basic get/set/delete."""
     client = MagicMock()
     store = {}
+    expiries = {}
 
     def mock_get(key):
         return store.get(key)
@@ -24,12 +25,34 @@ def mock_redis():
 
     def mock_setex(key, ttl, value):
         store[key] = value
+        expiries[key] = ttl
 
-    def mock_delete(key):
-        store.pop(key, None)
+    def mock_delete(*keys):
+        for item in keys:
+            store.pop(item, None)
+            expiries.pop(item, None)
+
+    def mock_sadd(key, value):
+        bucket = store.setdefault(key, set())
+        bucket.add(value)
+
+    def mock_smembers(key):
+        return set(store.get(key, set()))
+
+    def mock_srem(key, value):
+        bucket = store.get(key)
+        if isinstance(bucket, set):
+            bucket.discard(value)
+
+    def mock_ttl(key):
+        return expiries.get(key, -1)
 
     def mock_scan(cursor, match=None, count=100):
-        keys = [k for k in store if k.startswith(match.replace('*', ''))] if match else list(store)
+        if match:
+            prefix = match.split('*', 1)[0]
+            keys = [k for k in store if k.startswith(prefix)]
+        else:
+            keys = list(store)
         return (0, keys)
 
     def mock_lpop(key):
@@ -42,6 +65,10 @@ def mock_redis():
     client.set = mock_set
     client.setex = mock_setex
     client.delete = mock_delete
+    client.sadd = mock_sadd
+    client.smembers = mock_smembers
+    client.srem = mock_srem
+    client.ttl = mock_ttl
     client.scan = mock_scan
     client.lpop = mock_lpop
     client.rpush = mock_rpush

--- a/tests/test_monitor_central.py
+++ b/tests/test_monitor_central.py
@@ -1,4 +1,5 @@
 import os
+import time
 from unittest.mock import MagicMock, patch
 
 from monitor.central import CentralMonitor, ExtractTimeout
@@ -36,6 +37,87 @@ def test_detect_completion_allows_primary_gate_without_send_visible(mock_redis):
     assert generating is False
     assert completed is True
     notify.assert_called_once_with(session, "response_complete", "stop_button")
+
+
+def test_detect_completion_deep_research_waits_for_second_stop_cycle(mock_redis):
+    with patch.object(CentralMonitor, "_connect_redis", return_value=mock_redis):
+        monitor = CentralMonitor()
+
+    session = {
+        "platform": "gemini",
+        "monitor_id": "mon-deep",
+        "mode": "deep_research",
+        "started_ts": 0,
+        "timeout": 7200,
+    }
+
+    with patch.object(monitor, "_notify") as notify:
+        first_generating = monitor._detect_completion(
+            session,
+            {
+                "stop_found": True,
+                "send_visible": False,
+                "content_hash": "hash-1",
+            },
+        )
+        plan_transition = monitor._detect_completion(
+            session,
+            {
+                "stop_found": False,
+                "send_visible": False,
+                "content_hash": "hash-2",
+            },
+        )
+        second_generating = monitor._detect_completion(
+            session,
+            {
+                "stop_found": True,
+                "send_visible": False,
+                "content_hash": "hash-3",
+            },
+        )
+        completed = monitor._detect_completion(
+            session,
+            {
+                "stop_found": False,
+                "send_visible": False,
+                "content_hash": "hash-4",
+            },
+        )
+
+    assert first_generating is False
+    assert plan_transition is False
+    assert second_generating is False
+    assert completed is True
+    assert mock_redis.get("taey:monitor:mon-deep:stop_cycles") == "2"
+    notify.assert_called_once_with(session, "response_complete", "stop_button")
+
+
+def test_detect_completion_deep_think_requires_full_stop_transition(mock_redis):
+    with patch.object(CentralMonitor, "_connect_redis", return_value=mock_redis):
+        monitor = CentralMonitor()
+
+    session = {
+        "platform": "gemini",
+        "monitor_id": "mon-think",
+        "mode": "deep_think",
+        "started_ts": time.time(),
+        "timeout": 7200,
+    }
+
+    with patch.object(monitor, "_notify") as notify:
+        poll_without_transition = monitor._detect_completion(
+            session,
+            {
+                "stop_found": False,
+                "send_visible": False,
+                "content_hash": "",
+            },
+        )
+
+    assert poll_without_transition is False
+    assert mock_redis.get("taey:monitor:mon-think:stop_cycles") is None
+    notify.assert_not_called()
 
 
 def test_notify_extracts_and_stores_after_response_complete(mock_redis):

--- a/tests/test_pipeline_regression.py
+++ b/tests/test_pipeline_regression.py
@@ -95,6 +95,26 @@ def test_audit_passes_send_with_audit_passed(mock_redis):
     assert error is None
 
 
+def test_register_monitor_session_stores_mode(mock_redis):
+    """Monitor session registration must persist the selected mode."""
+    from tools.send import register_monitor_session
+    from storage.redis_pool import node_key
+
+    result = register_monitor_session(
+        platform='gemini',
+        monitor_id='mon-mode',
+        url='https://example.test/chat',
+        redis_client=mock_redis,
+        mode='deep_research',
+    )
+
+    assert result == {"registered": True, "monitor_id": "mon-mode"}
+
+    session_key = node_key("active_session:mon-mode")
+    session = json.loads(mock_redis.get(session_key))
+    assert session["mode"] == "deep_research"
+
+
 # ── Test 4: Grok fresh_session triggers F5 on stale URL ────────────────────
 
 def test_grok_fresh_session_triggers_reload():

--- a/tools/send.py
+++ b/tools/send.py
@@ -100,6 +100,7 @@ def register_monitor_session(platform: str, monitor_id: str, url: str,
                              redis_client, session_id: str = None,
                              user_message_id: str = None,
                              tmux_session: str = None,
+                             mode: str = None,
                              timeout: int = 7200) -> Dict[str, Any]:
     """Register active session for the central monitor to track."""
     if not redis_client:
@@ -112,6 +113,7 @@ def register_monitor_session(platform: str, monitor_id: str, url: str,
         "session_id": session_id,
         "user_message_id": user_message_id,
         "tmux_session": tmux_session or NODE_ID,
+        "mode": mode,
         "stop_seen": False,
         "generating_since": None,
         "started_ts": time.time(),
@@ -230,6 +232,18 @@ def handle_send_message(platform: str, message: str,
     # Register monitor session BEFORE Enter (chat platforms only)
     monitor_id = str(uuid.uuid4())[:8]
     monitor_registered = False
+    mode = None
+
+    if redis_client:
+        plan_id = redis_client.get(node_key(f"plan:current:{platform}"))
+        if plan_id:
+            plan_json = redis_client.get(node_key(f"plan:{plan_id}"))
+            if plan_json:
+                try:
+                    plan = json.loads(plan_json)
+                    mode = plan.get('required_state', {}).get('mode') or plan.get('mode')
+                except (json.JSONDecodeError, TypeError):
+                    logger.debug("Could not decode current plan for monitor mode", exc_info=True)
 
     if platform not in SOCIAL_PLATFORMS:
         _ensure_central_monitor(display)
@@ -237,6 +251,7 @@ def handle_send_message(platform: str, message: str,
             platform=platform, monitor_id=monitor_id, url=url,
             redis_client=redis_client, session_id=session_id,
             user_message_id=message_id,
+            mode=mode,
         )
         monitor_registered = reg.get("registered", False)
 


### PR DESCRIPTION
## Summary
- require two stop-button appearance/disappearance cycles before completing deep research and deep think monitor sessions
- persist monitor stop cycle state in Redis and clear it with the rest of monitor session state
- store the planned mode on registered monitor sessions and add regression tests for deep-mode completion and mode persistence

## Testing
- pytest -q tests/test_monitor_central.py
- pytest -q tests/test_pipeline_regression.py -k register_monitor_session_stores_mode

## Notes
- ....F.                                                                   [100%]
=================================== FAILURES ===================================
___________________ test_grok_fresh_session_triggers_reload ____________________

    def test_grok_fresh_session_triggers_reload():
        """When fresh_session=True and Grok AT-SPI URL contains /c/, F5 must fire."""
        mock_redis = MagicMock()
        mock_redis.get.return_value = None
    
        with patch('tools.inspect.inp') as mock_inp, \
             patch('tools.inspect.atspi') as mock_atspi:
    
            # switch_to_platform succeeds
            mock_inp.switch_to_platform.return_value = True
            mock_inp.clipboard_paste.return_value = True
            mock_inp.press_key.return_value = True
    
            # AT-SPI returns a stale conversation URL
            mock_ff = MagicMock()
            mock_atspi.find_firefox_for_platform.return_value = mock_ff
            mock_doc = MagicMock()
            mock_atspi.get_platform_document.return_value = mock_doc
            mock_atspi.get_document_url.return_value = 'https://grok.com/c/old-convo-id'
            mock_atspi.detect_display.return_value = ':0'
    
            from tools.inspect import handle_inspect
>           handle_inspect('grok', mock_redis, fresh_session=True)

tests/test_pipeline_regression.py:142: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tools/inspect.py:410: in handle_inspect
    sc = _check_structure_change(platform, elements_json, redis_client)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tools/inspect.py:222: in _check_structure_change
    current_hash = compute_structure_hash(elements, screen_height=SCREEN_HEIGHT)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
core/tree.py:397: in compute_structure_hash
    band_height = max(screen_height // grid_rows, 1)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
core/platforms.py:46: in __floordiv__
    def __floordiv__(self, o): return int(self) // o
                                      ^^^^^^^^^
core/platforms.py:40: in __int__
    return get_screen_size()[self._idx]
           ^^^^^^^^^^^^^^^^^
core/platforms.py:31: in get_screen_size
    _screen_size = _detect_screen_size()
                   ^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def _detect_screen_size() -> tuple:
        """Detect screen dimensions via xdpyinfo."""
        try:
            result = subprocess.run(
                ['xdpyinfo'], capture_output=True, text=True, timeout=5,
                env={**os.environ},
            )
            for line in result.stdout.splitlines():
                if 'dimensions:' in line:
                    w, h = line.strip().split()[1].split('x')
                    return int(w), int(h)
        except Exception as e:
            raise RuntimeError(f"Screen size detection failed: {e}")
>       raise RuntimeError("No 'dimensions:' line in xdpyinfo output")
E       RuntimeError: No 'dimensions:' line in xdpyinfo output

core/platforms.py:21: RuntimeError
=========================== short test summary info ============================
FAILED tests/test_pipeline_regression.py::test_grok_fresh_session_triggers_reload
1 failed, 5 passed in 13.98s still has a pre-existing unrelated failure in  because  tries to read live screen dimensions from  in this environment.