### PR TITLE
Fix ChatGPT Pro Extended verification

### DIFF
--- a/platforms/chatgpt.yaml
+++ b/platforms/chatgpt.yaml
@@ -83,6 +83,9 @@ mode_guidance:
         select: pro
       - trigger: null
         select: extended
+    verification:
+      check: completed_steps
+      expected_steps: 2
     timeout: 14400
   extended_thinking:
     when: "Alias for pro_extended"

--- a/scripts/consultation.py
+++ b/scripts/consultation.py
@@ -901,9 +901,22 @@ def _verify_mode_selection(platform: str, target_mode: str, selection_result: di
     verified = False
     verify_method = 'none'
     selection_result = selection_result or {}
+    mode_key = _normalize_mode_key(target_mode)
+    mode_guidance = get_platform_config(platform).get('mode_guidance', {})
+    mode_config = mode_guidance.get(mode_key, {})
+    verification_config = mode_config.get('verification', {})
+    verification_check = verification_config.get('check')
 
     selected_item = selection_result.get('selected_item')
-    if selection_result.get('success') and selected_item:
+    if verification_check == 'completed_steps':
+        completed_steps = selection_result.get('completed_steps') or []
+        expected_steps = verification_config.get('expected_steps')
+        if selection_result.get('success') and len(completed_steps) == expected_steps:
+            logger.info("Mode verified via completed steps: %s/%s",
+                        len(completed_steps), expected_steps)
+            verified = True
+            verify_method = 'completed_steps'
+    elif selection_result.get('success') and selected_item:
         selected_name = selected_item.replace('_', ' ').lower().strip()
         target_lower = target_mode.replace('_', ' ').lower().strip()
         if target_lower in selected_name or selected_name.startswith(target_lower):

--- a/tests/test_mode_select.py
+++ b/tests/test_mode_select.py
@@ -26,7 +26,31 @@ def test_chatgpt_mode_guidance():
     assert 'auto' in mg
     assert 'thinking' in mg
     assert 'pro' in mg
+    assert mg['pro_extended']['verification'] == {
+        'check': 'completed_steps',
+        'expected_steps': 2,
+    }
     assert mg['pro']['timeout'] == 7200
+
+
+def test_chatgpt_pro_extended_verifies_by_completed_steps():
+    import sys
+
+    sys.argv = ['consultation.py', '--platform', 'chatgpt', '--message', 'x']
+    from scripts import consultation
+
+    result = consultation._verify_mode_selection(
+        'chatgpt',
+        'pro_extended',
+        {
+            'success': True,
+            'selected_item': 'Extended Pro',
+            'completed_steps': [{'step': 1}, {'step': 2}],
+        },
+    )
+
+    assert result['verified'] is True
+    assert result['method'] == 'completed_steps'
 
 
 def test_gemini_mode_guidance():


### PR DESCRIPTION
## Summary
- add YAML-driven verification for ChatGPT `pro_extended`
- verify multi-step selection by completed step count instead of selected item text
- add regression coverage for the ChatGPT `Extended Pro` case

## Testing
- `pytest -q tests/test_mode_select.py`
- `python3 - <<PY
import sys
sys.argv=["consultation.py","--platform","chatgpt","--message","x"]
from scripts import consultation
print(consultation._verify_mode_selection("chatgpt","pro_extended", {"success": True, "selected_item": "Extended Pro", "completed_steps":[{"step":1},{"step":2}]}))
PY`
