### PR TITLE
fix: scroll Perplexity DR extract to report header

### DIFF
--- a/tools/extract.py
+++ b/tools/extract.py
@@ -413,6 +413,15 @@ def _try_perplexity_deep_research_extract(platform, firefox, doc, display: Optio
     if platform != 'perplexity':
         return None, 'not_applicable'
 
+    # Deep Research exposes the report-level "Copy contents" control at the top.
+    # Quick extract scrolls down first for generic copy flows, so reset to the top
+    # before trying the report-header button.
+    inp.press_key('ctrl+Home')
+    time.sleep(0.3)
+    inp.press_key('Home')
+    time.sleep(0.5)
+
+    doc = atspi.get_platform_document(firefox, platform) or doc
     copy_contents, _ = _find_copy_buttons_by_name(doc, 'copy contents')
     if not copy_contents:
         return None, 'not_applicable'


### PR DESCRIPTION
## Summary
- scroll Perplexity Deep Research extraction back to the top before searching for the report header button
- refresh the AT-SPI document after scrolling, then click `Copy contents` and read the clipboard
- keep the existing Perplexity quick-extract path through `_try_perplexity_deep_research_extract`

## Verification
- confirmed `handle_quick_extract` still calls `_try_perplexity_deep_research_extract` for Perplexity
- ran `python3 -m py_compile tools/extract.py`
