### PR TITLE
Fix multi-display worker tab targeting for Grok extraction

### DIFF
--- a/core/input.py
+++ b/core/input.py
@@ -143,6 +143,21 @@ def switch_to_platform(platform: str) -> bool:
     if platform not in URL_PATTERNS:
         return False
 
+    def _on_target(pid: int = None) -> bool:
+        firefox = atspi.find_firefox_for_platform(platform, pid=pid)
+        if not firefox:
+            return False
+        doc = atspi.get_platform_document(firefox, platform)
+        if not doc:
+            return False
+        try:
+            import gi
+            gi.require_version('Atspi', '2.0')
+            from gi.repository import Atspi as _A
+            return doc.get_state_set().contains(_A.StateType.SHOWING)
+        except Exception:
+            return False
+
     # Multi-display mode: switch DISPLAY and focus the right Firefox window
     plat_display = get_platform_display(platform)
     if plat_display:
@@ -166,31 +181,23 @@ def switch_to_platform(platform: str) -> bool:
                         env=_get_env(), capture_output=True, timeout=10,
                     )
                     time.sleep(0.3)
-                    return True
+                    if _on_target(pid=ff_pid):
+                        return True
             except subprocess.TimeoutExpired:
                 logger.warning(f"Multi-display focus timed out for PID {ff_pid}")
             except Exception as e:
                 logger.warning(f"Multi-display focus failed: {e}")
-        # Even without PID, DISPLAY is set correctly
-        return True
+        shortcut = TAB_SHORTCUTS.get(platform)
+        if shortcut:
+            press_key(shortcut)
+            time.sleep(0.5)
+            if _on_target(pid=ff_pid):
+                return True
+        logger.warning(f"Could not switch to {platform} on dedicated display {plat_display}")
+        return _on_target(pid=ff_pid)
 
     if not focus_firefox():
         return False
-
-    def _on_target() -> bool:
-        firefox = atspi.find_firefox(platform)
-        if not firefox:
-            return False
-        doc = atspi.get_platform_document(firefox, platform)
-        if not doc:
-            return False
-        try:
-            import gi
-            gi.require_version('Atspi', '2.0')
-            from gi.repository import Atspi as _A
-            return doc.get_state_set().contains(_A.StateType.SHOWING)
-        except Exception:
-            return False
 
     if _on_target():
         return True

--- a/tests/test_core_input.py
+++ b/tests/test_core_input.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import core.input as input_mod
+
+
+class _DummyStateSet:
+    def __init__(self, showing):
+        self._showing = showing
+
+    def contains(self, _state_type):
+        return self._showing
+
+
+class _DummyDoc:
+    def __init__(self, showing):
+        self._state_set = _DummyStateSet(showing)
+
+    def get_state_set(self):
+        return self._state_set
+
+
+def _fake_subprocess_run(*args, **kwargs):
+    cmd = args[0]
+    if cmd[:3] == ['xdotool', 'search', '--pid']:
+        return SimpleNamespace(returncode=0, stdout='111\n', stderr='')
+    if cmd[:2] == ['xdotool', 'windowactivate']:
+        return SimpleNamespace(returncode=0, stdout='', stderr='')
+    raise AssertionError(f"Unexpected subprocess command: {cmd}")
+
+
+def test_switch_to_platform_multidisplay_retargets_tab_when_window_focus_is_wrong():
+    fake_gi = MagicMock()
+    fake_atspi_enum = SimpleNamespace(StateType=SimpleNamespace(SHOWING=object()))
+    wrong_doc = _DummyDoc(showing=False)
+    right_doc = _DummyDoc(showing=True)
+
+    with patch.dict(
+        'sys.modules',
+        {
+            'gi': fake_gi,
+            'gi.repository': SimpleNamespace(Atspi=fake_atspi_enum),
+        },
+    ), patch('core.platforms.get_platform_display', return_value=':5'), \
+         patch('core.platforms.get_platform_firefox_pid', return_value=123), \
+         patch.dict('core.platforms.TAB_SHORTCUTS', {'grok': 'alt+4'}, clear=False), \
+         patch.dict('core.platforms.URL_PATTERNS', {'grok': 'grok.com'}, clear=False), \
+         patch('core.clipboard.set_display') as clip_set_display, \
+         patch('core.atspi.find_firefox_for_platform', return_value=object()), \
+         patch('core.atspi.get_platform_document', side_effect=[wrong_doc, right_doc]), \
+         patch('core.input.subprocess.run', side_effect=_fake_subprocess_run), \
+         patch('core.input.press_key', return_value=True) as press_key:
+        assert input_mod.switch_to_platform('grok') is True
+
+    clip_set_display.assert_called_once_with(':5')
+    press_key.assert_called_once_with('alt+4')
+
+
+def test_switch_to_platform_multidisplay_fails_when_tab_cannot_be_verified():
+    fake_gi = MagicMock()
+    fake_atspi_enum = SimpleNamespace(StateType=SimpleNamespace(SHOWING=object()))
+    wrong_doc = _DummyDoc(showing=False)
+
+    with patch.dict(
+        'sys.modules',
+        {
+            'gi': fake_gi,
+            'gi.repository': SimpleNamespace(Atspi=fake_atspi_enum),
+        },
+    ), patch('core.platforms.get_platform_display', return_value=':5'), \
+         patch('core.platforms.get_platform_firefox_pid', return_value=123), \
+         patch.dict('core.platforms.TAB_SHORTCUTS', {'grok': 'alt+4'}, clear=False), \
+         patch.dict('core.platforms.URL_PATTERNS', {'grok': 'grok.com'}, clear=False), \
+         patch('core.clipboard.set_display'), \
+         patch('core.atspi.find_firefox_for_platform', return_value=object()), \
+         patch('core.atspi.get_platform_document', side_effect=[wrong_doc, wrong_doc, wrong_doc]), \
+         patch('core.input.subprocess.run', side_effect=_fake_subprocess_run), \
+         patch('core.input.press_key', return_value=True) as press_key:
+        assert input_mod.switch_to_platform('grok') is False
+
+    press_key.assert_called_once_with('alt+4')


### PR DESCRIPTION
## Summary
- verify the active document after focusing a dedicated-display Firefox window before treating platform switch as successful
- fall back to the platform tab shortcut when the worker window is focused but the active tab drifted away from the requested platform
- add regression tests for the dedicated-display wrong-tab case that can send/extract from Google Search instead of Grok

## Notes
- `monitor/central.py::_notify()` already routes auto-extract through worker IPC on current `main`
- the remaining failure mode was worker-side tab drift on multi-display, not monitor-side AT-SPI bus initialization

## Testing
- `pytest -q tests/test_core_input.py tests/test_monitor_central.py tests/test_worker_manager.py`