### PR TITLE
fix(claude.yaml): prepend 'Model: ' to model_selector names

### DIFF
--- a/consultation_v2/platforms/claude.yaml
+++ b/consultation_v2/platforms/claude.yaml
@@ -89,14 +89,14 @@ tree:
     model_selector:
       # Exact current-model button names only; no substring matching.
       names:
-        - "Opus 4.7"
-        - "Opus 4.7 Adaptive"
-        - "Opus 4.6"
-        - "Opus 4.6 Extended"
-        - "Sonnet 4.6"
-        - "Sonnet 4.6 Extended"
-        - "Haiku 4.5"
-        - "Haiku 4.5 Extended"
+        - "Model: Opus 4.7"
+        - "Model: Opus 4.7 Adaptive"
+        - "Model: Opus 4.6"
+        - "Model: Opus 4.6 Extended"
+        - "Model: Sonnet 4.6"
+        - "Model: Sonnet 4.6 Extended"
+        - "Model: Haiku 4.5"
+        - "Model: Haiku 4.5 Extended"
       role: push button
 
     voice_mode:


### PR DESCRIPTION
## Summary
- AT-SPI now reports Claude.ai model selector buttons with the prefix `Model: ` (e.g. `Model: Opus 4.7 Adaptive`).
- The `element_map.model_selector.names` list omitted that prefix, so `mode_setup` could not locate the trigger button — blocking all Claude v2 dispatches at mode_setup.
- Drift confirmed via taeys-hands screenshot `/tmp/consult_claude_1776736573.png`.

## Change
Prepended `Model: ` to each of the 8 entries in `consultation_v2/platforms/claude.yaml` under `element_map.model_selector.names`. No other fields touched, no other YAML files modified.

## Test plan
- [ ] Re-run a Claude v2 dispatch and confirm `mode_setup` resolves the model_selector button
- [ ] Verify `extended_thinking_active` validation still passes (those indicators use the inner names without prefix and are unchanged)