### PR TITLE
fix(claude.yaml): update Adaptive thinking text + handle toggle redesign

### DIFF
--- a/consultation_v2/platforms/claude.yaml
+++ b/consultation_v2/platforms/claude.yaml
@@ -156,7 +156,13 @@ tree:
       role: radio menu item
 
     model_adaptive_thinking_item:
-      name: "Adaptive thinking Thinks only when needed Adaptive thinking"
+      # Anthropic redesigned this control as a toggle switch (default ON for
+      # Opus 4.7) with new description text. Keep role as 'menu item' until
+      # we have AT-SPI confirmation of the new role; the pre-check via
+      # extended_thinking_active.indicators (matching the trigger button
+      # name "Model: Opus 4.7 Adaptive") should skip mode_setup entirely
+      # when adaptive is already active, so the click rarely fires.
+      name: "Adaptive thinking Thinks for more complex tasks"
       role: menu item
 
     model_more_item:
@@ -348,36 +354,41 @@ validation:
 
   opus_active:
     indicators:
-      - name: "Opus 4.7"
+      - name: "Model: Opus 4.7"
         role: push button
-      - name: "Opus 4.7 Adaptive"
+      - name: "Model: Opus 4.7 Adaptive"
         role: push button
-      - name: "Opus 4.6"
+      - name: "Model: Opus 4.6"
         role: push button
-      - name: "Opus 4.6 Extended"
+      - name: "Model: Opus 4.6 Extended"
         role: push button
 
   sonnet_active:
     indicators:
-      - name: "Sonnet 4.6"
+      - name: "Model: Sonnet 4.6"
         role: push button
-      - name: "Sonnet 4.6 Extended"
+      - name: "Model: Sonnet 4.6 Extended"
         role: push button
 
   haiku_active:
     indicators:
-      - name: "Haiku 4.5"
+      - name: "Model: Haiku 4.5"
         role: push button
-      - name: "Haiku 4.5 Extended"
+      - name: "Model: Haiku 4.5 Extended"
         role: push button
 
   extended_thinking_active:
+    # Trigger-button names carry the "Model: " prefix after AT-SPI drift
+    # (see commit d1f8726). When mode_setup pre-checks this indicator
+    # block and the trigger button name already matches, mode_setup
+    # skips the dropdown click entirely — which is the right behavior
+    # for Opus 4.7 where Adaptive thinking is ON by default.
     indicators:
-      - name: "Opus 4.7 Adaptive"
+      - name: "Model: Opus 4.7 Adaptive"
         role: push button
-      - name: "Opus 4.6 Extended"
+      - name: "Model: Opus 4.6 Extended"
         role: push button
-      - name: "Sonnet 4.6 Extended"
+      - name: "Model: Sonnet 4.6 Extended"
         role: push button
-      - name: "Haiku 4.5 Extended"
+      - name: "Model: Haiku 4.5 Extended"
         role: push button


### PR DESCRIPTION
## Summary
- Update `model_adaptive_thinking_item.name` to the new Anthropic UI text (`Adaptive thinking Thinks for more complex tasks`) — old name no longer exists in the AT-SPI tree.
- Add `Model: ` prefix to all `*_active` indicator blocks (`opus_active`, `sonnet_active`, `haiku_active`, `extended_thinking_active`) so they actually match live trigger-button names. PR #147 added the prefix to `model_selector.names` but missed these blocks, so the pre-check that should let `mode_setup` skip the dropdown click never matched.
- Keep `model_adaptive_thinking_item.role` as `menu item` until we have AT-SPI confirmation of the new toggle role; the `extended_thinking_active.indicators` pre-check is the primary defense and skips the click entirely when adaptive is already on (default state for Opus 4.7).

## Why
Anthropic redesigned the Claude UI dropdown:
- `Adaptive thinking` is now a TOGGLE SWITCH (default ON for Opus 4.7), not a radio menu item.
- New description text: `Adaptive thinking Thinks for more complex tasks` (was `Adaptive thinking Thinks only when needed Adaptive thinking`).
- Trigger button shows `Model: Opus 4.7 Adaptive` on page load when adaptive is active.

With the indicator blocks now correctly prefixed, `mode_setup` for `extended_thinking` short-circuits via the `*_active` indicator check on Opus 4.7 — no dropdown click, no toggle interaction, no drift exposure.

## Test plan
- [x] `yaml.safe_load(open('consultation_v2/platforms/claude.yaml'))` parses cleanly.
- [x] `model_adaptive_thinking_item.name` confirmed updated to new text.
- [x] All 4 `extended_thinking_active.indicators` carry the `Model: ` prefix.
- [ ] Live AT-SPI run on `DISPLAY=:3` (Claude profile) to confirm `extended_thinking_active` matches and `mode_setup` skips the dropdown click on a fresh Opus 4.7 session.
- [ ] If Anthropic confirms the new role is `toggle button`, follow-up PR to update the role field (flagged in the YAML comment).

Single-file change. No other platform YAMLs touched.

[Generated with Claude Code](https://claude.com/claude-code)