### PR TITLE
fix(claude.yaml): upload_files_item drop Ctrl+U

### DIFF
--- a/consultation_v2/platforms/claude.yaml
+++ b/consultation_v2/platforms/claude.yaml
@@ -108,7 +108,7 @@ tree:
       role: push button
 
     upload_files_item:
-      name: "Add files or photos Ctrl+U"
+      name: "Add files or photos"
       role: menu item
 
     take_screenshot_item:


### PR DESCRIPTION
AT-SPI drift — live UI shows 'Add files or photos' without Ctrl+U shortcut. Blocks Claude v2 file attach.