### PR TITLE
revert(claude.yaml): restore 'Ctrl+U' suffix — AT-SPI tree still reports it

### DIFF
--- a/consultation_v2/platforms/claude.yaml
+++ b/consultation_v2/platforms/claude.yaml
@@ -108,7 +108,7 @@ tree:
       role: push button
 
     upload_files_item:
-      name: "Add files or photos"
+      name: "Add files or photos Ctrl+U"
       role: menu item
 
     take_screenshot_item:


### PR DESCRIPTION
Revert of PR #149. Misdiagnosis — visual cropping in screenshot suggested Anthropic dropped the keyboard shortcut, but live AT-SPI tree (manual scan with menu open) confirms 'Add files or photos Ctrl+U' is still the actual element name. Original first-attempt halt was likely transient menu render timing, not a YAML mismatch.