### PR TITLE
Root-cause false generation_stalled: thread mode from selections + gate stop-absence on healthy read (ea9a144e)

### DIFF
--- a/consultation_v2/drivers/base.py
+++ b/consultation_v2/drivers/base.py
@@ -32,6 +32,19 @@ from consultation_v2.yaml_contract import load_platform_yaml
 # (FLOW Monitor Contract: stop-present = generating; the timeout is the LOUD
 # bound for a genuinely-stuck run, never a content/elapsed completion heuristic.)
 DEEP_GENERATION_FLOOR_SECONDS = 1800.0
+# Minimum raw AT-SPI node count for a document snapshot to be a FAITHFUL read of
+# the page (and therefore for a stop-ABSENT observation drawn from it to be
+# trustworthy). A loaded consultation page — nav, sidebar history, composer,
+# toolbar, rendered response — always scans into the hundreds of raw nodes; a
+# starved/degraded read under concurrent AT-SPI bus contention returns a
+# near-empty tree (zero / single-digit nodes). This floor sits in the wide empty
+# gap between the two, so it never clips a real generating-or-complete page while
+# always catching a degenerate read. It bounds only the absence interpretation:
+# a degraded tick is treated as 'unknown' (skipped, debounce not advanced), never
+# as stop-gone. Because the monitor's wall-clock effective_timeout still bounds
+# the loop, an over-conservative misfire can only degrade to a LOUD timeout —
+# never a silent false-complete and never an infinite wait.
+MONITOR_MIN_HEALTHY_RAW_COUNT = 25
 PROMPT_ECHO_FAILURE_MESSAGE = 'extracted text matches prompt — echo, not a response'
 
 
@@ -2466,8 +2479,15 @@ class BaseConsultationDriver(ABC):
         validated send. Without that proof, this monitor call must observe Stop
         itself before Stop-gone can complete.
         """
+        # The selected mode lives in request.selections['mode'] (read via
+        # selection_value); ConsultationRequest has no `.mode` attribute, so the
+        # prior getattr(request, 'mode', None) ALWAYS yielded None -> '' ->
+        # 'default'. That silently collapsed deep modes to required_stop_cycles=1
+        # AND dropped their DEEP_GENERATION_FLOOR_SECONDS floor below. Read the
+        # real selected mode so deep modes get their intended 2-cycle stop-gone
+        # debounce + deep timeout floor.
         detector_mode = (
-            (mode if mode is not None else getattr(request, 'mode', None)) or ''
+            (mode if mode is not None else request.selection_value('mode', None)) or ''
         ).strip().lower()
         detector = CompletionDetector(mode=detector_mode)
         stop_key = self._stop_key()
@@ -2503,6 +2523,19 @@ class BaseConsultationDriver(ABC):
                 intermediate_failed = failed
                 return bool(failed)
             if stop_present:
+                return False
+            # Stop-key absent on this scan. An ABSENCE is only real information
+            # when it comes from a FAITHFUL read of the page: under concurrent
+            # AT-SPI bus contention a starved read returns a near-empty tree in
+            # which stop_key is absent NOT because generation finished but because
+            # the read itself failed. Feeding that to the detector as stop-gone is
+            # the false-completion root cause (compounded by BUG1's lost deep
+            # debounce). A degraded read is therefore 'unknown', not 'gone': skip
+            # the tick (debounce counter untouched) and keep polling. stop_present
+            # is unaffected — a visible stop means generating regardless of tree
+            # size — and the wall-clock effective_timeout still bounds a
+            # genuinely-stuck run, so this adds no infinite wait.
+            if int(snap.raw_count or 0) < MONITOR_MIN_HEALTHY_RAW_COUNT:
                 return False
             verdict = detector.observe(stop_present=False)
             if verdict == COMPLETE:


### PR DESCRIPTION
## MEASURE (6SIGMA, conductor-endorsed) — two compounding root-cause bugs

The completion monitor false-fails `generation_stalled` (live-reproduced on the tutor GB10 5-lane consult: perplexity DR "stalled" ~3min into a 3600s bound while the browser was actively researching). Root cause is TWO bugs, not the initial poll-count hypothesis (`runtime.wait_until` is wall-clock-correct; the "3600s" in the message is the cosmetic `effective_timeout`, not measured elapsed):

**BUG1 — mode not threaded (latent on ALL consults, a correctness win beyond the false-fail).** `base.py monitor_generation` derived `detector_mode` from `getattr(request, 'mode', None)` — `ConsultationRequest` has **no `.mode`** attribute (mode lives in `request.selections['mode']`, read via `request.selection_value('mode', …)`). So it was ALWAYS `'' → 'default' → required_stop_cycles=1`, and deep modes silently lost their `DEEP_GENERATION_FLOOR_SECONDS=1800` floor. (Impact: only gemini/grok/perplexity were bitten — claude.py and chatgpt.py override `monitor_generation` and already read mode via `selection_value`.)

**BUG2 — degraded snapshot misread as stop-gone.** In `_poll`, a starved/degraded `runtime.snapshot()` under concurrent AT-SPI bus contention has `stop_key` absent NOT because generation finished but because the read failed. With 1 cycle (from BUG1) + `seed_stop_seen`, a single such tick → `detector.observe(stop_present=False)` → COMPLETE → `wait_until` early-returns → post-loop `verify_snap` re-scan finds Stop STILL present → false `generation_stalled`.

## FIX (root-cause shape — SIMPLIFIES, no bypass branch)
`consultation_v2/drivers/base.py` only (+34/−1), commit `ea9a144e`:
1. **Thread mode from selections:** `getattr(request,'mode',None)` → `request.selection_value('mode', None)` → restores the intended 2-cycle stop-gone debounce + the 1800s deep floor.
2. **Stop-absent requires a faithful read:** before `detector.observe(stop_present=False)`, gate on `snap.raw_count >= MONITOR_MIN_HEALTHY_RAW_COUNT (25)`. A degraded read is 'unknown' (skip tick, debounce untouched, keep polling), never 'stop-gone'. This corrects the *derivation* of the absence observation fed to the (still-pure) detector — the same invariant `chatgpt.py` already enforces via `_read_stop_state(confirm_absence=…)` that the base monitor was missing. `stop_present=True` is unaffected.

## Audit mandate (grok + gatekeeper — LOGIC + shape, scoped; cannot drive the browser)
1. BUG1: `selection_value('mode')` is the correct accessor (types.py L90) and no driver double-passes `mode=` to `monitor_generation` (8 call sites checked).
2. BUG2: a degraded read no longer advances the debounce; a healthy stop-gone still completes; `stop_present=True` path unchanged.
3. **No infinite-wait / timeout regression:** the wall-clock `effective_timeout` (now correctly floored to 1800s for deep modes) still bounds `wait_until`. Worst case of an over-conservative `raw_count` floor = a LOUD timeout, never a silent false-complete.
4. Scope isolation: base.py shared monitor only; `completion.py` left pure; all platforms benefit.
5. The one tunable is `MONITOR_MIN_HEALTHY_RAW_COUNT = 25` — verify it sits below a real generating/complete-page raw_count and above a starved read for gemini/grok/perplexity. Failure direction is safe (loud timeout, not silent false-complete).

## Gate state (cannot-lie)
Compile + AST + grep shape-checks only (no tests, no browser — production is the oracle). gitnexus_impact: `monitor_generation` HIGH (callers grok/perplexity/gemini), `observe` LOW (signature unchanged). NOT production-run — **taeys-hands production-validates post-merge on the next real concurrent/deep multi-lane consult** (watch for correct completion, no false generation_stalled). Producer≠verifier: this PR is the audit surface; CONTROL merges on grok+gatekeeper green. Defect → revert + RCA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
