### PR TITLE
Split platform routing out of shared input/atspi

### DIFF
--- a/consultation_v2/atspi.py
+++ b/consultation_v2/atspi.py
@@ -14,8 +14,6 @@ import gi
 gi.require_version('Atspi', '2.0')
 from gi.repository import Atspi
 
-from consultation_v2.platforms_runtime import (URL_PATTERNS, _EXTRA_URL_PATTERNS)
-
 logger = logging.getLogger(__name__)
 
 
@@ -36,13 +34,11 @@ def detect_display() -> str:
     for num in range(100):
         if os.path.exists(f'/tmp/.X11-unix/X{num}'):
             return f':{num}'
-    raise RuntimeError("No X display detected — set DISPLAY env or start Xvfb")
+    raise RuntimeError("No X display detected - set DISPLAY env or start Xvfb")
 
 
-def find_firefox(platform: str = None):
-    """Find Firefox in AT-SPI desktop tree. Retries once with cache clear.
-    If platform is given and multiple Firefox instances exist, returns the
-    instance containing that platform's document (handles HMM bot profiles)."""
+def find_firefox():
+    """Find Firefox in the AT-SPI desktop tree. Retries once with cache clear."""
     for attempt in range(2):
         try:
             desktop = Atspi.get_desktop(0)
@@ -62,13 +58,6 @@ def find_firefox(platform: str = None):
                 return None
             if len(all_ff) == 1:
                 return all_ff[0]
-            # Multiple Firefox instances — need platform to disambiguate
-            if platform:
-                for ff in all_ff:
-                    doc = get_platform_document(ff, platform)
-                    if doc:
-                        return ff
-                logger.warning(f"No Firefox instance has {platform} document, returning first")
             return all_ff[0]
         except Exception as e:
             if attempt == 0:
@@ -100,30 +89,6 @@ def find_all_firefox(pid: int = None):
 
 
 
-def find_firefox_for_platform(platform: str, pid: int = None):
-    """Find the Firefox instance that has a document matching the given platform.
-    Handles multiple Firefox instances (parallel HMM mode).
-    If pid is given, restricts search to that process only.
-    Falls back to find_firefox() if only one instance exists.
-
-    Multi-display: per-display workers handle routing. Each worker has
-    the correct DISPLAY/AT-SPI bus, so this function always uses the
-    direct local AT-SPI path."""
-    all_ff = find_all_firefox(pid=pid)
-    if not all_ff:
-        return None
-    if len(all_ff) == 1:
-        return all_ff[0]
-    # Multiple Firefox instances — find the one with our platform's document
-    for ff in all_ff:
-        doc = get_platform_document(ff, platform)
-        if doc:
-            return ff
-    # None had the right document — fail, don't guess
-    logger.error(f"No Firefox instance has {platform} document")
-    return None
-
-
 def get_document_url(doc) -> str | None:
     """Extract DocURL from a document element."""
     try:
@@ -135,29 +100,12 @@ def get_document_url(doc) -> str | None:
     return None
 
 
-def detect_platform_from_url(url: str) -> str | None:
-    """Detect platform from URL. Checks specific patterns first."""
-    if not url:
-        return None
-    url_lower = url.lower()
-    for platform, pattern in _EXTRA_URL_PATTERNS.items():
-        if pattern in url_lower:
-            return platform
-    for platform, domain in URL_PATTERNS.items():
-        if domain in url_lower:
-            return platform
-    return None
-
-
-def get_platform_document(firefox, platform: str):
-    """Find the document web element for a platform by URL matching."""
-    if not firefox:
-        return None
-
+def document_web_elements(firefox, *, max_depth: int = 10) -> list:
+    """Return document-web descendants for a Firefox AT-SPI application root."""
     candidates = []
 
     def search(obj, depth=0):
-        if depth > 10:
+        if depth > max_depth:
             return
         try:
             if obj.get_role_name() == 'document web':
@@ -169,23 +117,9 @@ def get_platform_document(firefox, platform: str):
         except Exception:
             pass
 
-    search(firefox)
-
-    matches = [c for c in candidates if detect_platform_from_url(get_document_url(c)) == platform]
-    if not matches:
-        return None
-    if len(matches) == 1:
-        return matches[0]
-
-    # Prefer SHOWING (active tab)
-    for m in matches:
-        try:
-            if m.get_state_set().contains(Atspi.StateType.SHOWING):
-                return m
-        except Exception:
-            pass
-    matches.sort(key=lambda m: m.get_child_count(), reverse=True)
-    return matches[0]
+    if firefox:
+        search(firefox)
+    return candidates
 
 
 def is_file_dialog_open(firefox) -> bool:

--- a/consultation_v2/drivers/chatgpt.py
+++ b/consultation_v2/drivers/chatgpt.py
@@ -1548,10 +1548,10 @@ class ChatGPTConsultationDriver(BaseConsultationDriver):
         return None
 
     def _chatgpt_document(self):
-        from consultation_v2 import atspi as _atspi
+        from consultation_v2.platforms import routing as platform_routing
 
-        firefox = _atspi.find_firefox_for_platform(self.platform)
-        return _atspi.get_platform_document(firefox, self.platform) if firefox else None
+        firefox = platform_routing.find_firefox_for_platform(self.platform)
+        return platform_routing.get_platform_document(firefox, self.platform) if firefox else None
 
     def _scroll_chatgpt_thread_to_bottom(self) -> dict:
         from consultation_v2 import input as _inp
@@ -2082,8 +2082,8 @@ class ChatGPTConsultationDriver(BaseConsultationDriver):
 
     def extract_primary(self, request: ConsultationRequest, result: ConsultationResult) -> bool:
         from consultation_v2 import clipboard
-        from consultation_v2.atspi import find_firefox_for_platform, get_platform_document
         from consultation_v2.interact import atspi_click
+        from consultation_v2.platforms import routing as platform_routing
         from consultation_v2.tree import find_elements as raw_find_elements
 
         if not self.reassert_captured_session_url(
@@ -2114,7 +2114,7 @@ class ChatGPTConsultationDriver(BaseConsultationDriver):
                     snapshot=last_snapshot.serializable() if last_snapshot else {},
                 )
                 return False
-            firefox = find_firefox_for_platform(self.platform)
+            firefox = platform_routing.find_firefox_for_platform(self.platform)
             if not firefox:
                 attempts.append({
                     'attempt': attempt + 1,
@@ -2126,7 +2126,7 @@ class ChatGPTConsultationDriver(BaseConsultationDriver):
                 firefox.clear_cache_single()
             except Exception:
                 pass
-            document = get_platform_document(firefox, self.platform)
+            document = platform_routing.get_platform_document(firefox, self.platform)
             if not document:
                 attempts.append({
                     'attempt': attempt + 1,

--- a/consultation_v2/drivers/claude.py
+++ b/consultation_v2/drivers/claude.py
@@ -1181,9 +1181,9 @@ class ClaudeConsultationDriver(BaseConsultationDriver):
     def extract_primary(
         self, request: ConsultationRequest, result: ConsultationResult
     ) -> bool:
-        from consultation_v2.atspi import find_firefox_for_platform
         from consultation_v2.tree import find_elements as raw_find_elements
         from consultation_v2.interact import atspi_click
+        from consultation_v2.platforms import routing as platform_routing
 
         if not self.reassert_captured_session_url(
             result,
@@ -1212,7 +1212,7 @@ class ClaudeConsultationDriver(BaseConsultationDriver):
         for attempt in range(5):
             time.sleep(2.0)
             scroll_ok = self.runtime.scroll_document_to_bottom(clicks=14, rounds=3, settle=0.5)
-            firefox = find_firefox_for_platform(self.platform)
+            firefox = platform_routing.find_firefox_for_platform(self.platform)
             if not firefox:
                 continue
             try:
@@ -1348,9 +1348,9 @@ class ClaudeConsultationDriver(BaseConsultationDriver):
         have nothing to capture. Once the toggle is present, every subsequent
         step is tree/clipboard validated and failures abort extraction.
         """
-        from consultation_v2.atspi import find_firefox_for_platform
         from consultation_v2.tree import find_elements as raw_find_elements
         from consultation_v2.interact import atspi_click
+        from consultation_v2.platforms import routing as platform_routing
 
         snap = self.runtime.snapshot()
         show_toggle = self.find_last(snap, 'show_thinking')
@@ -1388,7 +1388,7 @@ class ClaudeConsultationDriver(BaseConsultationDriver):
                 )
                 return False
 
-        firefox = find_firefox_for_platform(self.platform)
+        firefox = platform_routing.find_firefox_for_platform(self.platform)
         if not firefox:
             result.add_step('extract_thinking', False, 'Claude Firefox window not found for thinking extraction')
             return False
@@ -1563,11 +1563,11 @@ class ClaudeConsultationDriver(BaseConsultationDriver):
         expected_names: list[str],
         attempts: list[dict],
     ) -> dict | None:
-        from consultation_v2.atspi import find_firefox_for_platform
         from consultation_v2.interact import atspi_click
+        from consultation_v2.platforms import routing as platform_routing
         from consultation_v2.tree import find_elements as raw_find_elements
 
-        firefox = find_firefox_for_platform(self.platform)
+        firefox = platform_routing.find_firefox_for_platform(self.platform)
         if not firefox:
             attempts.append({
                 'source': 'artifact_tree_copy_button',

--- a/consultation_v2/input.py
+++ b/consultation_v2/input.py
@@ -183,117 +183,28 @@ def focus_firefox(timeout: int = 5) -> bool:
         return False
 
 
-def switch_to_platform(platform: str) -> bool:
-    """Switch to a platform tab via Alt+N shortcut.
-    Multi-display mode: switches DISPLAY to the platform's dedicated display."""
-    from consultation_v2.platforms_runtime import (
-        TAB_SHORTCUTS, URL_PATTERNS, get_platform_display, get_platform_firefox_pid,
-    )
-    from consultation_v2 import atspi
-
-    if platform not in URL_PATTERNS:
+def focus_firefox_pid(pid: int | None, timeout: int = 5) -> bool:
+    """Activate a Firefox window by process id using raw X11 window operations."""
+    if not pid:
         return False
-
-    def _on_target(pid: int = None) -> bool:
-        if plat_display:
-            set_display(plat_display)
-        firefox = atspi.find_firefox_for_platform(platform, pid=pid)
-        if not firefox:
+    try:
+        r = subprocess.run(
+            ['xdotool', 'search', '--pid', str(pid), '--name', ''],
+            env=_get_env(), capture_output=True, text=True, timeout=timeout,
+        )
+        wids = [w.strip() for w in r.stdout.strip().split('\n') if w.strip()]
+        if not wids:
             return False
-        doc = atspi.get_platform_document(firefox, platform)
-        if not doc:
-            return False
-        try:
-            import gi
-            gi.require_version('Atspi', '2.0')
-            from gi.repository import Atspi as _A
-            return doc.get_state_set().contains(_A.StateType.SHOWING)
-        except Exception:
-            return False
-
-    # Multi-display mode: switch DISPLAY and focus the right Firefox window
-    plat_display = get_platform_display(platform)
-    if plat_display:
-        set_display(plat_display)
-        from consultation_v2.clipboard import set_display as clip_set_display
-        clip_set_display(plat_display)
-
-        def _focus_firefox_pid(pid: int | None) -> bool:
-            if not pid:
-                return False
-            try:
-                r = subprocess.run(
-                    ['xdotool', 'search', '--pid', str(pid), '--name', ''],
-                    env=_get_env(), capture_output=True, text=True, timeout=5,
-                )
-                wids = [w.strip() for w in r.stdout.strip().split('\n') if w.strip()]
-                if not wids:
-                    return False
-                subprocess.run(
-                    ['xdotool', 'windowactivate', wids[-1]],
-                    env=_get_env(), capture_output=True, text=True, timeout=10,
-                )
-                time.sleep(0.3)
-                return True
-            except subprocess.TimeoutExpired:
-                logger.warning(f"Multi-display focus timed out for PID {pid}")
-            except Exception as e:
-                logger.warning(f"Multi-display focus failed for PID {pid}: {e}")
-            return False
-
-        ff_pid = get_platform_firefox_pid(platform)
-        if ff_pid:
-            if _focus_firefox_pid(ff_pid) and _on_target(pid=ff_pid):
-                return True
-        else:
-            logger.warning(f"No Firefox PID file for {platform}; falling back to AT-SPI discovery")
-
-        discovered_firefox = atspi.find_firefox_for_platform(platform)
-        discovered_pid = None
-        if discovered_firefox:
-            try:
-                discovered_pid = discovered_firefox.get_process_id()
-            except Exception:
-                discovered_pid = None
-
-            if discovered_pid and discovered_pid != ff_pid:
-                logger.warning(
-                    f"Stale Firefox PID {ff_pid} for {platform}; AT-SPI discovered PID {discovered_pid}"
-                )
-
-            if _focus_firefox_pid(discovered_pid) and _on_target(pid=discovered_pid):
-                return True
-            if focus_firefox() and _on_target(pid=discovered_pid):
-                return True
-
-        shortcut = TAB_SHORTCUTS.get(platform)
-        if shortcut:
-            press_key(shortcut)
-            time.sleep(0.5)
-            if _on_target(pid=discovered_pid or ff_pid):
-                return True
-        logger.warning(f"Could not switch to {platform} on dedicated display {plat_display}")
-        return _on_target(pid=discovered_pid or ff_pid)
-
-    if not focus_firefox():
-        return False
-
-    if _on_target():
+        subprocess.run(
+            ['xdotool', 'windowactivate', wids[-1]],
+            env=_get_env(), capture_output=True, text=True, timeout=10,
+        )
+        time.sleep(0.3)
         return True
-
-    shortcut = TAB_SHORTCUTS.get(platform)
-    if shortcut:
-        press_key(shortcut)
-        time.sleep(0.5)
-        return True
-
-    # No shortcut: Ctrl+Tab cycling
-    for _ in range(8):
-        press_key('ctrl+Tab')
-        time.sleep(0.4)
-        if _on_target():
-            return True
-    logger.warning(f"Could not switch to {platform}")
+    except subprocess.TimeoutExpired:
+        logger.warning(f"Firefox PID focus timed out for PID {pid}")
+    except Exception as e:
+        logger.warning(f"Firefox PID focus failed for PID {pid}: {e}")
     return False
 
 

--- a/consultation_v2/platforms/_routing_core.py
+++ b/consultation_v2/platforms/_routing_core.py
@@ -1,0 +1,167 @@
+"""Mechanical helpers used by package-owned platform routing modules."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+
+from consultation_v2 import atspi, clipboard, input as input_core
+from consultation_v2.platforms_runtime import get_platform_display, get_platform_firefox_pid
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RouteSpec:
+    platform: str
+    url_patterns: tuple[str, ...]
+    extra_url_patterns: tuple[str, ...] = ()
+    default_tab_shortcut: str | None = None
+    worker_tab_shortcut: str | None = None
+
+
+def url_matches(spec: RouteSpec, url: str | None) -> bool:
+    if not url:
+        return False
+    url_lower = url.lower()
+    for pattern in spec.extra_url_patterns:
+        if pattern.lower() in url_lower:
+            return True
+    for pattern in spec.url_patterns:
+        if pattern.lower() in url_lower:
+            return True
+    return False
+
+
+def get_document(spec: RouteSpec, firefox):
+    if not firefox:
+        return None
+    matches = [
+        candidate
+        for candidate in atspi.document_web_elements(firefox)
+        if url_matches(spec, atspi.get_document_url(candidate))
+    ]
+    if not matches:
+        return None
+    if len(matches) == 1:
+        return matches[0]
+
+    for match in matches:
+        try:
+            if match.get_state_set().contains(atspi.Atspi.StateType.SHOWING):
+                return match
+        except Exception:
+            pass
+    matches.sort(key=lambda match: match.get_child_count(), reverse=True)
+    return matches[0]
+
+
+def find_firefox(spec: RouteSpec, *, pid: int | None = None):
+    all_firefox = atspi.find_all_firefox(pid=pid)
+    if not all_firefox:
+        return None
+    if len(all_firefox) == 1:
+        return all_firefox[0]
+    for firefox in all_firefox:
+        if get_document(spec, firefox):
+            return firefox
+    logger.error("No Firefox instance has %s document", spec.platform)
+    return None
+
+
+def tab_shortcut(spec: RouteSpec) -> str | None:
+    profile = os.environ.get('TAEY_TAB_PROFILE', 'default').strip().lower()
+    if profile == 'worker':
+        return spec.worker_tab_shortcut
+    if profile != 'default':
+        raise RuntimeError(f"Unsupported TAEY_TAB_PROFILE={profile!r}; expected default or worker")
+    return spec.default_tab_shortcut
+
+
+def _document_showing(spec: RouteSpec, *, display: str | None, pid: int | None) -> bool:
+    if display:
+        input_core.set_display(display)
+    firefox = find_firefox(spec, pid=pid)
+    if not firefox:
+        return False
+    doc = get_document(spec, firefox)
+    if not doc:
+        return False
+    try:
+        return doc.get_state_set().contains(atspi.Atspi.StateType.SHOWING)
+    except Exception:
+        return False
+
+
+def switch_to_platform(spec: RouteSpec) -> bool:
+    display = get_platform_display(spec.platform)
+    if display:
+        input_core.set_display(display)
+        clipboard.set_display(display)
+
+        firefox_pid = get_platform_firefox_pid(spec.platform)
+        if firefox_pid:
+            if input_core.focus_firefox_pid(firefox_pid) and _document_showing(
+                spec, display=display, pid=firefox_pid,
+            ):
+                return True
+        else:
+            logger.warning(
+                "No Firefox PID file for %s; falling back to AT-SPI discovery",
+                spec.platform,
+            )
+
+        discovered_firefox = find_firefox(spec)
+        discovered_pid = None
+        if discovered_firefox:
+            try:
+                discovered_pid = discovered_firefox.get_process_id()
+            except Exception:
+                discovered_pid = None
+
+            if discovered_pid and discovered_pid != firefox_pid:
+                logger.warning(
+                    "Stale Firefox PID %s for %s; AT-SPI discovered PID %s",
+                    firefox_pid,
+                    spec.platform,
+                    discovered_pid,
+                )
+
+            if input_core.focus_firefox_pid(discovered_pid) and _document_showing(
+                spec, display=display, pid=discovered_pid,
+            ):
+                return True
+            if input_core.focus_firefox() and _document_showing(
+                spec, display=display, pid=discovered_pid,
+            ):
+                return True
+
+        shortcut = tab_shortcut(spec)
+        if shortcut:
+            input_core.press_key(shortcut)
+            time.sleep(0.5)
+            if _document_showing(spec, display=display, pid=discovered_pid or firefox_pid):
+                return True
+        logger.warning("Could not switch to %s on dedicated display %s", spec.platform, display)
+        return _document_showing(spec, display=display, pid=discovered_pid or firefox_pid)
+
+    if not input_core.focus_firefox():
+        return False
+    if _document_showing(spec, display=None, pid=None):
+        return True
+
+    shortcut = tab_shortcut(spec)
+    if shortcut:
+        input_core.press_key(shortcut)
+        time.sleep(0.5)
+        return True
+
+    for _ in range(8):
+        input_core.press_key('ctrl+Tab')
+        time.sleep(0.4)
+        if _document_showing(spec, display=None, pid=None):
+            return True
+    logger.warning("Could not switch to %s", spec.platform)
+    return False

--- a/consultation_v2/platforms/chatgpt/routing.py
+++ b/consultation_v2/platforms/chatgpt/routing.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from consultation_v2.platforms._routing_core import (
+    RouteSpec,
+    find_firefox as _find_firefox,
+    get_document as _get_document,
+    switch_to_platform as _switch_to_platform,
+    url_matches as _url_matches,
+)
+
+_SPEC = RouteSpec(
+    platform='chatgpt',
+    url_patterns=('chatgpt.com',),
+    default_tab_shortcut='alt+1',
+    worker_tab_shortcut='alt+1',
+)
+
+
+def url_matches(url: str | None) -> bool:
+    return _url_matches(_SPEC, url)
+
+
+def get_document(firefox):
+    return _get_document(_SPEC, firefox)
+
+
+def find_firefox(*, pid: int | None = None):
+    return _find_firefox(_SPEC, pid=pid)
+
+
+def switch_to_platform() -> bool:
+    return _switch_to_platform(_SPEC)

--- a/consultation_v2/platforms/claude/routing.py
+++ b/consultation_v2/platforms/claude/routing.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from consultation_v2.platforms._routing_core import (
+    RouteSpec,
+    find_firefox as _find_firefox,
+    get_document as _get_document,
+    switch_to_platform as _switch_to_platform,
+    url_matches as _url_matches,
+)
+
+_SPEC = RouteSpec(
+    platform='claude',
+    url_patterns=('claude.ai',),
+    default_tab_shortcut='alt+2',
+    worker_tab_shortcut='alt+2',
+)
+
+
+def url_matches(url: str | None) -> bool:
+    return _url_matches(_SPEC, url)
+
+
+def get_document(firefox):
+    return _get_document(_SPEC, firefox)
+
+
+def find_firefox(*, pid: int | None = None):
+    return _find_firefox(_SPEC, pid=pid)
+
+
+def switch_to_platform() -> bool:
+    return _switch_to_platform(_SPEC)

--- a/consultation_v2/platforms/gemini/routing.py
+++ b/consultation_v2/platforms/gemini/routing.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from consultation_v2.platforms._routing_core import (
+    RouteSpec,
+    find_firefox as _find_firefox,
+    get_document as _get_document,
+    switch_to_platform as _switch_to_platform,
+    url_matches as _url_matches,
+)
+
+_SPEC = RouteSpec(
+    platform='gemini',
+    url_patterns=('gemini.google.com',),
+    default_tab_shortcut='alt+3',
+    worker_tab_shortcut='alt+3',
+)
+
+
+def url_matches(url: str | None) -> bool:
+    return _url_matches(_SPEC, url)
+
+
+def get_document(firefox):
+    return _get_document(_SPEC, firefox)
+
+
+def find_firefox(*, pid: int | None = None):
+    return _find_firefox(_SPEC, pid=pid)
+
+
+def switch_to_platform() -> bool:
+    return _switch_to_platform(_SPEC)

--- a/consultation_v2/platforms/grok/routing.py
+++ b/consultation_v2/platforms/grok/routing.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from consultation_v2.platforms._routing_core import (
+    RouteSpec,
+    find_firefox as _find_firefox,
+    get_document as _get_document,
+    switch_to_platform as _switch_to_platform,
+    url_matches as _url_matches,
+)
+
+_SPEC = RouteSpec(
+    platform='grok',
+    url_patterns=('grok.com',),
+    extra_url_patterns=('x.com/i/grok',),
+    default_tab_shortcut='alt+4',
+    worker_tab_shortcut='alt+4',
+)
+
+
+def url_matches(url: str | None) -> bool:
+    return _url_matches(_SPEC, url)
+
+
+def get_document(firefox):
+    return _get_document(_SPEC, firefox)
+
+
+def find_firefox(*, pid: int | None = None):
+    return _find_firefox(_SPEC, pid=pid)
+
+
+def switch_to_platform() -> bool:
+    return _switch_to_platform(_SPEC)

--- a/consultation_v2/platforms/perplexity/routing.py
+++ b/consultation_v2/platforms/perplexity/routing.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from consultation_v2.platforms._routing_core import (
+    RouteSpec,
+    find_firefox as _find_firefox,
+    get_document as _get_document,
+    switch_to_platform as _switch_to_platform,
+    url_matches as _url_matches,
+)
+
+_SPEC = RouteSpec(
+    platform='perplexity',
+    url_patterns=('perplexity.ai',),
+    default_tab_shortcut='alt+5',
+    worker_tab_shortcut=None,
+)
+
+
+def url_matches(url: str | None) -> bool:
+    return _url_matches(_SPEC, url)
+
+
+def get_document(firefox):
+    return _get_document(_SPEC, firefox)
+
+
+def find_firefox(*, pid: int | None = None):
+    return _find_firefox(_SPEC, pid=pid)
+
+
+def switch_to_platform() -> bool:
+    return _switch_to_platform(_SPEC)

--- a/consultation_v2/platforms/routing.py
+++ b/consultation_v2/platforms/routing.py
@@ -1,0 +1,35 @@
+"""Dispatch to package-owned platform routing modules."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+
+
+def _route_module(platform: str) -> ModuleType:
+    platform_name = str(platform or '').strip()
+    if not platform_name.isidentifier() or platform_name.startswith('_'):
+        raise RuntimeError(f'Invalid platform route name: {platform!r}')
+    module_name = f'consultation_v2.platforms.{platform_name}.routing'
+    try:
+        return import_module(module_name)
+    except ModuleNotFoundError as exc:
+        if exc.name == module_name:
+            raise RuntimeError(f'No package routing module for platform: {platform_name}') from exc
+        raise
+
+
+def switch_to_platform(platform: str) -> bool:
+    return bool(_route_module(platform).switch_to_platform())
+
+
+def find_firefox_for_platform(platform: str, *, pid: int | None = None):
+    return _route_module(platform).find_firefox(pid=pid)
+
+
+def get_platform_document(firefox, platform: str):
+    return _route_module(platform).get_document(firefox)
+
+
+def platform_url_matches(platform: str, url: str | None) -> bool:
+    return bool(_route_module(platform).url_matches(url))

--- a/consultation_v2/platforms_runtime.py
+++ b/consultation_v2/platforms_runtime.py
@@ -1,4 +1,4 @@
-"""Platform definitions: URL patterns, tab shortcuts, screen detection."""
+"""Shared display and screen runtime plumbing."""
 
 import os
 import re
@@ -51,53 +51,6 @@ class _LazyDim:
 
 SCREEN_WIDTH = _LazyDim(0)
 SCREEN_HEIGHT = _LazyDim(1)
-
-# Tab shortcuts. Dedicated-display deployments do not use tab switching;
-# TAEY_TAB_PROFILE keeps the legacy reduced-tab mode explicit when needed.
-_DEFAULT_TABS = {
-    'chatgpt': 'alt+1', 'claude': 'alt+2', 'gemini': 'alt+3',
-    'grok': 'alt+4', 'perplexity': 'alt+5', 'x_twitter': 'alt+6',
-}
-_WORKER_TABS = {
-    'chatgpt': 'alt+1', 'claude': 'alt+2', 'gemini': 'alt+3', 'grok': 'alt+4',
-}
-
-_TAB_PROFILE = os.environ.get('TAEY_TAB_PROFILE', 'default').strip().lower()
-if _TAB_PROFILE not in {'default', 'worker'}:
-    raise RuntimeError(f"Unsupported TAEY_TAB_PROFILE={_TAB_PROFILE!r}; expected default or worker")
-TAB_SHORTCUTS = _WORKER_TABS if _TAB_PROFILE == 'worker' else _DEFAULT_TABS
-
-# URL patterns for platform detection (order: specific first)
-_EXTRA_URL_PATTERNS = {'grok': 'x.com/i/grok'}
-URL_PATTERNS = {
-    'chatgpt': 'chatgpt.com', 'claude': 'claude.ai',
-    'gemini': 'gemini.google.com', 'grok': 'grok.com',
-    'perplexity': 'perplexity.ai', 'x_twitter': 'x.com',
-    'linkedin': 'linkedin.com',
-    # Treasurer-side platforms used by external automation.
-    'upwork': 'upwork.com',
-    'lesswrong': 'lesswrong.com',
-    'reddit': 'reddit.com',
-    'nvidia_forum': 'developer.nvidia.com',  # matches both forums.developer.nvidia.com and login on developer.nvidia.com
-    'ea_funds': 'effectivealtruism.org',
-    'paperform': 'paperform.co',  # EA Funds form host
-}
-
-BASE_URLS = {
-    'chatgpt': 'https://chatgpt.com/',
-    'claude': 'https://claude.ai/new',
-    'gemini': 'https://gemini.google.com/app',
-    'grok': 'https://grok.com/',
-    'perplexity': 'https://perplexity.ai/',
-    'x_twitter': '<AUXILIARY_URL>',
-    'linkedin': 'https://www.linkedin.com/feed/',
-    'reddit': '<AUXILIARY_URL>',
-    'nvidia_forum': '<AUXILIARY_URL>/',
-}
-
-CHAT_PLATFORMS = {'chatgpt', 'claude', 'gemini', 'grok', 'perplexity'}
-SOCIAL_PLATFORMS = {'x_twitter', 'linkedin', 'reddit', 'nvidia_forum'}
-ALL_PLATFORMS = CHAT_PLATFORMS | SOCIAL_PLATFORMS
 
 # Multi-display support.
 # Sources, in precedence order:

--- a/consultation_v2/runtime.py
+++ b/consultation_v2/runtime.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Iterable, Optional
 
 from consultation_v2 import atspi, clipboard, input as inp
 from consultation_v2.interact import atspi_click
+from consultation_v2.platforms import routing as platform_routing
 from consultation_v2.platforms_runtime import display_environment, get_platform_display
 from consultation_v2.tree import find_elements
 from .snapshot import build_app_root_snapshot, build_menu_snapshot, build_snapshot
@@ -152,11 +153,11 @@ class ConsultationRuntime:
     # ------------------------------------------------------------------
 
     def switch(self) -> bool:
-        if inp.switch_to_platform(self.platform):
+        if platform_routing.switch_to_platform(self.platform):
             return True
         # Fallback: if DISPLAY is already set correctly for this platform,
         # just verify Firefox is accessible on the current display
-        firefox = atspi.find_firefox_for_platform(self.platform)
+        firefox = platform_routing.find_firefox_for_platform(self.platform)
         if firefox:
             return True
         return False
@@ -181,13 +182,13 @@ class ConsultationRuntime:
             _Atspi.get_desktop(0).clear_cache_single()
         except Exception:
             pass
-        firefox = atspi.find_firefox_for_platform(self.platform)
+        firefox = platform_routing.find_firefox_for_platform(self.platform)
         if firefox is not None:
             try:
                 firefox.clear_cache_single()
             except Exception:
                 pass
-        doc = atspi.get_platform_document(firefox, self.platform) if firefox else None
+        doc = platform_routing.get_platform_document(firefox, self.platform) if firefox else None
         if doc is not None:
             try:
                 doc.clear_cache_single()
@@ -372,7 +373,7 @@ class ConsultationRuntime:
         return clicked
 
     def _generic_popup_dismiss_control(self) -> dict | None:
-        firefox = atspi.find_firefox_for_platform(self.platform)
+        firefox = platform_routing.find_firefox_for_platform(self.platform)
         if firefox is None:
             return None
         try:
@@ -534,8 +535,8 @@ class ConsultationRuntime:
             gi.require_version('Atspi', '2.0')
             from gi.repository import Atspi as _Atspi
 
-            firefox = atspi.find_firefox_for_platform(self.platform)
-            doc = atspi.get_platform_document(firefox, self.platform) if firefox else None
+            firefox = platform_routing.find_firefox_for_platform(self.platform)
+            doc = platform_routing.get_platform_document(firefox, self.platform) if firefox else None
             comp = doc.get_component_iface() if doc is not None else None
             rect = comp.get_extents(_Atspi.CoordType.SCREEN) if comp is not None else None
             if rect and rect.width > 0 and rect.height > 0:

--- a/consultation_v2/snapshot.py
+++ b/consultation_v2/snapshot.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 import yaml
 
 from consultation_v2 import atspi
+from consultation_v2.platforms import routing as platform_routing
 from consultation_v2.tree import find_elements, find_menu_items
 
 from .types import ElementRef, Snapshot
@@ -637,14 +638,14 @@ def build_snapshot(platform: str, scan_root: str = 'auto') -> Tuple[Any, Any, Sn
         desktop.clear_cache_single()
     except Exception:
         pass
-    firefox = atspi.find_firefox_for_platform(platform)
+    firefox = platform_routing.find_firefox_for_platform(platform)
     if not firefox:
         raise RuntimeError(f'Firefox not found for {platform}')
     try:
         firefox.clear_cache_single()
     except Exception:
         pass
-    doc = atspi.get_platform_document(firefox, platform)
+    doc = platform_routing.get_platform_document(firefox, platform)
     if not doc:
         # Document not found — page may have navigated (e.g., Perplexity Deep Research toggle).
         # Fall back to scanning from Firefox app root.
@@ -702,10 +703,10 @@ def build_menu_snapshot(platform: str) -> Tuple[Any, Any, Snapshot]:
         desktop.clear_cache_single()
     except Exception:
         pass
-    firefox = atspi.find_firefox_for_platform(platform)
+    firefox = platform_routing.find_firefox_for_platform(platform)
     if not firefox:
         raise RuntimeError(f'Firefox not found for {platform}')
-    doc = atspi.get_platform_document(firefox, platform)
+    doc = platform_routing.get_platform_document(firefox, platform)
     # NOTE: menu_snapshot is the post-click portal/dropdown scope. Keep the scan
     # rooted at Firefox, not the document, so React overlays outside the document
     # subtree are visible while browser chrome remains pruned below.
@@ -788,7 +789,7 @@ def build_app_root_snapshot(
     control, never as the general tree.
     """
     chrome_cfg = _load_firefox_chrome_filter()
-    firefox = atspi.find_firefox_for_platform(platform)
+    firefox = platform_routing.find_firefox_for_platform(platform)
     if not firefox:
         raise RuntimeError(f'Firefox not found for {platform}')
     elements = find_elements(firefox)

--- a/consultation_v2/validation/platform_independence_residue_split/GENERATIVE_DISPOSITION_TABLE.md
+++ b/consultation_v2/validation/platform_independence_residue_split/GENERATIVE_DISPOSITION_TABLE.md
@@ -1,0 +1,76 @@
+# Residue Split Generative Disposition Table
+
+Pinned implementation commit: `c3e5cf9fe44af0f192a8c06cb2ec048516652218`.
+Rebased base: `origin/main` at `aab81c5c394ea9cbc3782760489a8d5c919a3104`.
+
+Observed basis: implementation diff, `PLATFORM_INDEPENDENCE_SPEC.md` section 4, local validator output, and GitNexus impact results for the removed shared AT-SPI routing helpers. Claims are labeled as Observed, Inferred, or Unknown.
+
+## Disposition
+
+| Module | Disposition | Provenance |
+| --- | --- | --- |
+| `consultation_v2/input.py` | Observed: reclassified as leaf. Platform routing function `switch_to_platform(platform)` was removed. Remaining public primitives are raw keyboard, mouse, scroll, paste, Firefox focus, and PID focus operations. | `consultation_v2/input.py:25`, `consultation_v2/input.py:43`, `consultation_v2/input.py:79`, `consultation_v2/input.py:110`, `consultation_v2/input.py:129`, `consultation_v2/input.py:186`; lint reports 11 leaf modules. |
+| `consultation_v2/atspi.py` | Observed: reclassified as leaf. Platform URL detection and platform document lookup were removed. Remaining public primitives are display detection, raw Firefox enumeration, DocURL extraction, raw document-web enumeration, and file-dialog probing. | `consultation_v2/atspi.py:20`, `consultation_v2/atspi.py:40`, `consultation_v2/atspi.py:70`, `consultation_v2/atspi.py:92`, `consultation_v2/atspi.py:103`, `consultation_v2/atspi.py:125`; lint reports 11 leaf modules. |
+| `consultation_v2/platforms_runtime.py` | Observed: no longer owns platform URL patterns, base URLs, tab shortcuts, or chat/social platform sets. It remains shared display and screen runtime plumbing. | `consultation_v2/platforms_runtime.py:1`, `consultation_v2/platforms_runtime.py:10`, `consultation_v2/platforms_runtime.py:191`, `consultation_v2/platforms_runtime.py:217`. |
+| `consultation_v2/platforms/_routing_core.py` | Observed: new shared routing mechanics parameterized by package-owned `RouteSpec`; no global platform registry. Preserves invalid `TAEY_TAB_PROFILE` fail-loud behavior. | `consultation_v2/platforms/_routing_core.py:16`, `consultation_v2/platforms/_routing_core.py:25`, `consultation_v2/platforms/_routing_core.py:38`, `consultation_v2/platforms/_routing_core.py:61`, `consultation_v2/platforms/_routing_core.py:74`, `consultation_v2/platforms/_routing_core.py:98`. |
+| `consultation_v2/platforms/routing.py` | Observed: shared runtime dispatcher imports `consultation_v2.platforms.<platform>.routing` by validated platform name. Platform packages do not import this dispatcher. | `consultation_v2/platforms/routing.py:8`, `consultation_v2/platforms/routing.py:22`, `consultation_v2/platforms/routing.py:26`, `consultation_v2/platforms/routing.py:30`. |
+| `consultation_v2/platforms/chatgpt/routing.py` | Observed: package owns ChatGPT URL and tab route data. | `consultation_v2/platforms/chatgpt/routing.py:11`. |
+| `consultation_v2/platforms/claude/routing.py` | Observed: package owns Claude URL and tab route data. | `consultation_v2/platforms/claude/routing.py:11`. |
+| `consultation_v2/platforms/gemini/routing.py` | Observed: package owns Gemini URL and tab route data. | `consultation_v2/platforms/gemini/routing.py:11`. |
+| `consultation_v2/platforms/grok/routing.py` | Observed: package owns Grok URL, extra `x.com/i/grok` route, and tab route data. | `consultation_v2/platforms/grok/routing.py:11`, `consultation_v2/platforms/grok/routing.py:14`. |
+| `consultation_v2/platforms/perplexity/routing.py` | Observed: package owns Perplexity URL and tab route data. Worker profile intentionally has no Perplexity tab shortcut. | `consultation_v2/platforms/perplexity/routing.py:11`, `consultation_v2/platforms/perplexity/routing.py:15`. |
+| `consultation_v2/runtime.py` | Observed: runtime no longer imports platform routing from `input.py` or `atspi.py`; it uses the package dispatcher. | `consultation_v2/runtime.py:11`, `consultation_v2/runtime.py:153`, `consultation_v2/runtime.py:159`, `consultation_v2/runtime.py:182`, `consultation_v2/runtime.py:190`, `consultation_v2/runtime.py:373`, `consultation_v2/runtime.py:535`. |
+| `consultation_v2/snapshot.py` | Observed: snapshot builders use the package dispatcher for Firefox/document resolution. | `consultation_v2/snapshot.py:10`, `consultation_v2/snapshot.py:638`, `consultation_v2/snapshot.py:647`, `consultation_v2/snapshot.py:703`, `consultation_v2/snapshot.py:706`, `consultation_v2/snapshot.py:789`. |
+| `consultation_v2/drivers/chatgpt.py` | Observed: legacy driver call sites use the package dispatcher. | `consultation_v2/drivers/chatgpt.py:1549`, `consultation_v2/drivers/chatgpt.py:1552`, `consultation_v2/drivers/chatgpt.py:2085`, `consultation_v2/drivers/chatgpt.py:2117`, `consultation_v2/drivers/chatgpt.py:2129`. |
+| `consultation_v2/drivers/claude.py` | Observed: legacy driver call sites use the package dispatcher. | `consultation_v2/drivers/claude.py:1184`, `consultation_v2/drivers/claude.py:1215`, `consultation_v2/drivers/claude.py:1351`, `consultation_v2/drivers/claude.py:1391`, `consultation_v2/drivers/claude.py:1566`, `consultation_v2/drivers/claude.py:1570`. |
+| `consultation_v2/validators/lint_platform_independence.py` | Observed: `input.py` and `atspi.py` are now leaf lint targets; routing-only package dirs for flat-YAML platforms do not falsely fail driver-entry checks. | `consultation_v2/validators/lint_platform_independence.py:28`, `consultation_v2/validators/lint_platform_independence.py:38`, `consultation_v2/validators/lint_platform_independence.py:39`, `consultation_v2/validators/lint_platform_independence.py:307`. |
+
+## GitNexus Risk Disposition
+
+| Removed shared symbol | GitNexus impact before removal | Disposition |
+| --- | --- | --- |
+| `consultation_v2/atspi.py::find_firefox_for_platform` | Observed from GitNexus: CRITICAL, impactedCount 7, direct 4, 6 affected processes. Direct callers were ChatGPT `extract_primary`, Claude `extract_primary`, Claude `extract_thinking_notes`, and Claude `_copy_artifact_from_tree_controls`. | Observed: all direct indexed callers now import `consultation_v2.platforms.routing` and call `platform_routing.find_firefox_for_platform`. |
+| `consultation_v2/atspi.py::get_platform_document` | Observed from GitNexus: CRITICAL, impactedCount 9, direct 3, 6 affected processes. | Observed: document lookup now lives behind package-owned routing modules; indexed driver/runtime/snapshot call sites use `platform_routing.get_platform_document`. |
+| `consultation_v2/atspi.py::detect_platform_from_url` | Observed from GitNexus: CRITICAL, impactedCount 8, direct 1, 5 affected processes through `get_platform_document`. | Observed: the URL-to-platform function was removed; each package routing module owns its `url_matches` data. |
+| `consultation_v2/input.py::switch_to_platform` | Unknown from GitNexus: target was not indexed and impact returned risk UNKNOWN. | Observed by diff/lint: the function was removed from `input.py`; runtime switching now calls `platform_routing.switch_to_platform`. |
+
+Post-rebase `mcp__gitnexus.detect_changes(scope=compare, base_ref=origin/main)` and the same call with base commit `aab81c5c394ea9cbc3782760489a8d5c919a3104` returned no changed symbols in this peer worktree. That result is recorded as a detector limitation; the GitNexus evidence for the split is the explicit CRITICAL impact analysis above plus the rebased Git diff.
+
+## Verification
+
+```text
+python3 -m py_compile consultation_v2/input.py consultation_v2/atspi.py consultation_v2/platforms/_routing_core.py consultation_v2/platforms/routing.py consultation_v2/platforms/chatgpt/routing.py consultation_v2/platforms/claude/routing.py consultation_v2/platforms/gemini/routing.py consultation_v2/platforms/grok/routing.py consultation_v2/platforms/perplexity/routing.py consultation_v2/runtime.py consultation_v2/snapshot.py consultation_v2/drivers/chatgpt.py consultation_v2/drivers/claude.py consultation_v2/validators/lint_platform_independence.py consultation_v2/platforms_runtime.py
+python3 consultation_v2/validators/lint_platform_independence.py --all
+python3 consultation_v2/validators/lint_platform_independence.py --self-test
+python3 consultation_v2/validators/lint_exact_match.py
+python3 consultation_v2/validators/lint_no_yaml_silent_fallbacks.py --all
+python3 consultation_v2/validators/lint_consultation_v2_contract.py --all
+python3 - <<'PY'
+import os
+from consultation_v2.platforms import routing
+from consultation_v2.platforms._routing_core import tab_shortcut
+from consultation_v2.platforms.chatgpt import routing as chatgpt_routing
+from consultation_v2.platforms.perplexity import routing as perplexity_routing
+for p in ['chatgpt', 'claude', 'gemini', 'grok', 'perplexity']:
+    mod = routing._route_module(p)
+    print(p, mod.__name__, mod.url_matches('https://example.com'))
+print('chatgpt', routing.platform_url_matches('chatgpt', 'https://chatgpt.com/c/abc'))
+print('grok-x', routing.platform_url_matches('grok', 'https://x.com/i/grok'))
+print('grok-domain', routing.platform_url_matches('grok', 'https://grok.com/'))
+print('perplexity', routing.platform_url_matches('perplexity', 'https://perplexity.ai/search'))
+os.environ['TAEY_TAB_PROFILE'] = 'worker'
+print('worker-chatgpt-tab', tab_shortcut(chatgpt_routing._SPEC))
+print('worker-perplexity-tab', tab_shortcut(perplexity_routing._SPEC))
+os.environ['TAEY_TAB_PROFILE'] = 'bogus'
+try:
+    tab_shortcut(chatgpt_routing._SPEC)
+except RuntimeError as exc:
+    print('invalid-profile', str(exc))
+else:
+    raise SystemExit('invalid profile did not fail')
+PY
+```
+
+Observed results: compile exited 0; platform isolation lint CLEAN with 5 packages, 11 leaf modules, 0 findings; self-test PASS; exact-match lint PASS; YAML silent fallback lint CLEAN; consultation_v2 contract lint CLEAN; dispatcher smoke matched ChatGPT, Grok domain, Grok x.com, and Perplexity URLs, preserved worker Perplexity no-tab behavior, and failed loudly on invalid `TAEY_TAB_PROFILE`.
+
+Unknown: no live browser consultation was run from this branch. This slice is ready for PR/r5 review after Grok PR #6 sequencing.

--- a/consultation_v2/validation/platform_independence_residue_split/ROUTING_SPLIT_AUDIT.md
+++ b/consultation_v2/validation/platform_independence_residue_split/ROUTING_SPLIT_AUDIT.md
@@ -1,0 +1,80 @@
+# Residue Split Routing Audit
+
+Pinned implementation commit: `c3e5cf9fe44af0f192a8c06cb2ec048516652218`.
+Rebased base: `origin/main` at `aab81c5c394ea9cbc3782760489a8d5c919a3104`.
+
+Task: `consult-platform-independence::residue-split-input-atspi`.
+
+## Cannot-Lie Summary
+
+Observed: the old shared platform routing in `consultation_v2/input.py`, `consultation_v2/atspi.py`, and `consultation_v2/platforms_runtime.py` has been split out of those modules.
+
+Observed: the five chat platforms now own their URL and tab route data in package-local `routing.py` modules:
+- `consultation_v2/platforms/chatgpt/routing.py`
+- `consultation_v2/platforms/claude/routing.py`
+- `consultation_v2/platforms/gemini/routing.py`
+- `consultation_v2/platforms/grok/routing.py`
+- `consultation_v2/platforms/perplexity/routing.py`
+
+Observed: the residual shared core is mechanical:
+- `consultation_v2/input.py`: raw key, click, hover, scroll, type, Firefox focus, and PID focus.
+- `consultation_v2/atspi.py`: display detection, AT-SPI desktop traversal, raw Firefox enumeration, DocURL extraction, raw document-web enumeration, and file-dialog detection.
+- `consultation_v2/platforms_runtime.py`: display allocation and screen runtime plumbing.
+
+Inferred from GitNexus impact: this was a CRITICAL shared-routing split because the old AT-SPI routing helpers fed ChatGPT and Claude extraction/monitor flows. The direct indexed callers were remediated to package routing.
+
+Unknown: `input.switch_to_platform` was not indexed by GitNexus, so its unreachability is proven by implementation diff, validator coverage, and runtime call-site diff rather than by GitNexus.
+
+## Moved Routing
+
+| Platform | Package route data | URL data | Tab data |
+| --- | --- | --- | --- |
+| ChatGPT | `consultation_v2/platforms/chatgpt/routing.py:11` | `chatgpt.com` | default `alt+1`, worker `alt+1` |
+| Claude | `consultation_v2/platforms/claude/routing.py:11` | `claude.ai` | default `alt+2`, worker `alt+2` |
+| Gemini | `consultation_v2/platforms/gemini/routing.py:11` | `gemini.google.com` | default `alt+3`, worker `alt+3` |
+| Grok | `consultation_v2/platforms/grok/routing.py:11` | `grok.com`, extra `x.com/i/grok` | default `alt+4`, worker `alt+4` |
+| Perplexity | `consultation_v2/platforms/perplexity/routing.py:11` | `perplexity.ai` | default `alt+5`, worker `None` |
+
+The package modules call shared mechanics from `consultation_v2/platforms/_routing_core.py`, but the registry data lives in the owning package module. The dispatcher in `consultation_v2/platforms/routing.py` exists for shared runtime callers; platform packages do not import it.
+
+## Shared-Core Reclassification
+
+| Module | Leaf claim | Evidence |
+| --- | --- | --- |
+| `consultation_v2/input.py` | Leaf after split. No platform-specific routing function remains. | `focus_firefox_pid` is raw PID focus at `consultation_v2/input.py:186`; isolation lint includes the file as leaf at `consultation_v2/validators/lint_platform_independence.py:38`. |
+| `consultation_v2/atspi.py` | Leaf after split. URL-to-platform and platform document matching moved out. | `document_web_elements` is raw document enumeration at `consultation_v2/atspi.py:103`; isolation lint includes the file as leaf at `consultation_v2/validators/lint_platform_independence.py:39`. |
+| `consultation_v2/platforms_runtime.py` | Shared display/runtime, not route registry. | Module description and exports now cover screen/display plumbing starting at `consultation_v2/platforms_runtime.py:1`. |
+
+## Call-Site Reroute
+
+Observed:
+- `ConsultationRuntime.switch`, `current_url`, popup dismissal, and scroll-point logic use `consultation_v2.platforms.routing`.
+- `snapshot.build_snapshot`, `build_menu_snapshot`, and `build_app_root_snapshot` use package routing.
+- Legacy ChatGPT and Claude driver extraction helpers use package routing.
+
+These are the call sites GitNexus identified as affected for the old AT-SPI helpers, plus the runtime/snapshot shared callers found in the implementation diff.
+
+## GitNexus Notes
+
+Pre-edit impact results:
+- `find_firefox_for_platform` in `consultation_v2/atspi.py`: CRITICAL, impactedCount 7, direct 4, 6 affected processes.
+- `get_platform_document` in `consultation_v2/atspi.py`: CRITICAL, impactedCount 9, direct 3, 6 affected processes.
+- `detect_platform_from_url` in `consultation_v2/atspi.py`: CRITICAL, impactedCount 8, direct 1, 5 affected processes.
+- `switch_to_platform` in `consultation_v2/input.py`: UNKNOWN, target not indexed.
+
+Pre-commit `mcp__gitnexus.detect_changes(scope=staged)` returned no changed symbols in this peer worktree. That result was recorded as a tool/worktree limitation, not as evidence that the diff was empty. The implementation evidence is the Git diff plus the impact call graph above.
+
+Post-rebase `mcp__gitnexus.detect_changes(scope=compare, base_ref=origin/main)` and the same call with base commit `aab81c5c394ea9cbc3782760489a8d5c919a3104` returned no changed symbols in this peer worktree. That result is recorded as a detector limitation, not as evidence that the PR diff is empty. The implementation evidence is the rebased Git diff plus the explicit CRITICAL impact call graph above.
+
+## Gate Results
+
+Observed clean:
+- `python3 -m py_compile ...` for all touched Python files.
+- `python3 consultation_v2/validators/lint_platform_independence.py --all`
+- `python3 consultation_v2/validators/lint_platform_independence.py --self-test`
+- `python3 consultation_v2/validators/lint_exact_match.py`
+- `python3 consultation_v2/validators/lint_no_yaml_silent_fallbacks.py --all`
+- `python3 consultation_v2/validators/lint_consultation_v2_contract.py --all`
+- Dispatcher smoke for all five package routing modules, ChatGPT URL match, Grok domain match, Grok `x.com/i/grok` match, Perplexity URL match, worker tab profile, and invalid `TAEY_TAB_PROFILE` fail-loud behavior.
+
+Unknown: no live browser production run was executed from this branch; PR/r5 sequencing belongs after Grok PR #6.

--- a/consultation_v2/validation/platform_independence_residue_split/SLICE_DIFF.md
+++ b/consultation_v2/validation/platform_independence_residue_split/SLICE_DIFF.md
@@ -1,0 +1,54 @@
+# Residue Split Slice Diff
+
+Pinned implementation commit: `c3e5cf9fe44af0f192a8c06cb2ec048516652218`.
+Rebased base: `origin/main` at `aab81c5c394ea9cbc3782760489a8d5c919a3104`.
+Observed diff range: `c3e5cf9^..c3e5cf9`.
+
+## Name Status
+```text
+M	consultation_v2/atspi.py
+M	consultation_v2/drivers/chatgpt.py
+M	consultation_v2/drivers/claude.py
+M	consultation_v2/input.py
+A	consultation_v2/platforms/_routing_core.py
+A	consultation_v2/platforms/chatgpt/routing.py
+A	consultation_v2/platforms/claude/routing.py
+A	consultation_v2/platforms/gemini/routing.py
+A	consultation_v2/platforms/grok/routing.py
+A	consultation_v2/platforms/perplexity/routing.py
+A	consultation_v2/platforms/routing.py
+M	consultation_v2/platforms_runtime.py
+M	consultation_v2/runtime.py
+M	consultation_v2/snapshot.py
+M	consultation_v2/validators/lint_platform_independence.py
+```
+
+## Diffstat
+```text
+consultation_v2/atspi.py                           |  84 ++---------
+consultation_v2/drivers/chatgpt.py                 |  12 +-
+consultation_v2/drivers/claude.py                  |  12 +-
+consultation_v2/input.py                           | 127 +++-------------
+consultation_v2/platforms/_routing_core.py         | 167 +++++++++++++++++++++
+consultation_v2/platforms/chatgpt/routing.py       |  32 ++++
+consultation_v2/platforms/claude/routing.py        |  32 ++++
+consultation_v2/platforms/gemini/routing.py        |  32 ++++
+consultation_v2/platforms/grok/routing.py          |  33 ++++
+consultation_v2/platforms/perplexity/routing.py    |  32 ++++
+consultation_v2/platforms/routing.py               |  35 +++++
+consultation_v2/platforms_runtime.py               |  49 +-----
+consultation_v2/runtime.py                         |  15 +-
+consultation_v2/snapshot.py                        |  11 +-
+consultation_v2/validators/lint_platform_independence.py | 4 +
+15 files changed, 422 insertions(+), 255 deletions(-)
+```
+
+## Slice Summary
+- `consultation_v2/input.py` no longer owns platform tab/display routing. It retains raw xdotool primitives plus `focus_firefox_pid` at `consultation_v2/input.py:186`.
+- `consultation_v2/atspi.py` no longer owns URL-to-platform routing or platform document lookup. It retains AT-SPI desktop plumbing, raw Firefox discovery, DocURL extraction, and raw document-web enumeration at `consultation_v2/atspi.py:40`, `consultation_v2/atspi.py:70`, `consultation_v2/atspi.py:92`, and `consultation_v2/atspi.py:103`.
+- `consultation_v2/platforms_runtime.py` no longer exports URL patterns, base URLs, tab shortcuts, or platform class sets. It retains shared display and screen runtime plumbing.
+- Each chat platform now has an owning `consultation_v2/platforms/<platform>/routing.py` module containing its URL patterns and tab routing data.
+- `consultation_v2/platforms/_routing_core.py` is a package-routing helper. It accepts package-owned `RouteSpec` data and contains no platform registry.
+- `consultation_v2/platforms/routing.py` is a dispatcher for shared runtime call sites; platform packages do not import it.
+- Runtime, snapshot, and legacy ChatGPT/Claude driver call sites now route through `consultation_v2.platforms.routing` instead of importing routing helpers from `input.py` or `atspi.py`.
+- `consultation_v2/validators/lint_platform_independence.py` reclassifies `input.py` and `atspi.py` as leaf modules and permits routing-only package directories for the four not-yet-extracted packages.

--- a/consultation_v2/validators/lint_platform_independence.py
+++ b/consultation_v2/validators/lint_platform_independence.py
@@ -35,6 +35,8 @@ LEAF_MODULES = (
     Path('consultation_v2/storage_policy.py'),
     Path('consultation_v2/ingest.py'),
     Path('consultation_v2/stop_conditions.py'),
+    Path('consultation_v2/input.py'),
+    Path('consultation_v2/atspi.py'),
 )
 FORBIDDEN_SHARED_MODULES = ('consultation_v2.drivers.base', 'consultation_v2.completion')
 DELIVERY_GATE = 'reject_prompt_echo_response'
@@ -305,6 +307,8 @@ def _scan_driver_entry_contract(package_dir: Path, root: Path) -> list[Finding]:
     package_name = package_dir.name
     display = _display_path(driver, root)
     if not driver.exists():
+        if (package_dir / 'routing.py').exists() and not (package_dir / f'{package_name}.yaml').exists():
+            return findings
         return [Finding(
             display, 1, 'package-driver-missing',
             'each platform package must expose driver.py with run() and reject_prompt_echo_response',


### PR DESCRIPTION
## Summary

- Moves platform tab/URL/Firefox routing out of `consultation_v2/input.py`, `consultation_v2/atspi.py`, and `consultation_v2/platforms_runtime.py`.
- Adds package-owned routing modules for ChatGPT, Claude, Gemini, Grok, and Perplexity, with a thin shared routing core that consumes package-owned `RouteSpec` data.
- Reclassifies `input.py` and `atspi.py` as leaf modules in the platform-independence lint and adds validation artifacts under `consultation_v2/validation/platform_independence_residue_split/`.

## Rebase

Rebased onto current `origin/main` at `aab81c5c394ea9cbc3782760489a8d5c919a3104`, which includes Grok PR #6 as squash commit `c0f22ad5`. The PR branch now has only two commits over main:

- `c3e5cf9fe44af0f192a8c06cb2ec048516652218` - implementation
- `901d929fca9f58e5a5425fd002a525da82ec3b5c` - validation artifacts

## Validation

- `python3 -m py_compile consultation_v2/input.py consultation_v2/atspi.py consultation_v2/platforms/_routing_core.py consultation_v2/platforms/routing.py consultation_v2/platforms/chatgpt/routing.py consultation_v2/platforms/claude/routing.py consultation_v2/platforms/gemini/routing.py consultation_v2/platforms/grok/routing.py consultation_v2/platforms/perplexity/routing.py consultation_v2/runtime.py consultation_v2/snapshot.py consultation_v2/drivers/chatgpt.py consultation_v2/drivers/claude.py consultation_v2/validators/lint_platform_independence.py consultation_v2/platforms_runtime.py`
- `python3 consultation_v2/validators/lint_platform_independence.py --all`
- `python3 consultation_v2/validators/lint_platform_independence.py --self-test`
- `python3 consultation_v2/validators/lint_exact_match.py`
- `python3 consultation_v2/validators/lint_no_yaml_silent_fallbacks.py --all`
- `python3 consultation_v2/validators/lint_consultation_v2_contract.py --all`
- Shared-routing import/constant scan: no hits.
- Dispatcher smoke for all five routing packages, URL matches, worker tab profile, and invalid `TAEY_TAB_PROFILE` fail-loud behavior.

## GitNexus

- Explicit impact on old AT-SPI routing helpers remains CRITICAL: `find_firefox_for_platform`, `get_platform_document`, and `detect_platform_from_url` feed extraction/monitor paths.
- `input.switch_to_platform` is not indexed by GitNexus and returns UNKNOWN; removal is verified by diff/lint/call-site reroute.
- Post-rebase `detect_changes(compare, base_ref=origin/main)` returned no changed symbols in this peer worktree, recorded as a detector limitation in the validation artifacts.

## Production

No live browser production consultation was run by this worker. Supervisor requested re-report after rebase; production Grok validation will be run by the supervisor/runner before r5 merge.