### PR TITLE
DR extract fallback chain: echo-strip, popup cleanup, mode-3 continue (three production failure modes)

### DIFF
--- a/consultation_v2/platforms/perplexity/driver.py
+++ b/consultation_v2/platforms/perplexity/driver.py
@@ -20,7 +20,7 @@ from consultation_v2.platforms.perplexity.monitor import COMPLETE, DEEP_MODES, P
 from consultation_v2.stop_conditions import is_stop_condition
 from consultation_v2 import primitives
 from consultation_v2 import storage_policy
-from consultation_v2.display_readiness import display_for_platform
+from consultation_v2.display_readiness import _viewable_windows, display_for_platform
 from consultation_v2.display_watchdog import pause_display_watchdog
 from consultation_v2.planner import SelectionPlanError, build_selection_plan, has_selection_menus
 from consultation_v2.runtime import ConsultationRuntime
@@ -3306,6 +3306,70 @@ class PerplexityConsultationDriver(_PerplexityInlineBase):
                 return True
         return False
 
+    @staticmethod
+    def _x_window_geometry(window_id: str, env: dict[str, str]) -> tuple[int, int] | None:
+        try:
+            result = subprocess.run(
+                ['xwininfo', '-id', window_id],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                env=env,
+            )
+        except Exception:
+            return None
+        if result.returncode != 0 or 'IsViewable' not in result.stdout:
+            return None
+        width_match = re.search(r'Width:\s*(\d+)', result.stdout)
+        height_match = re.search(r'Height:\s*(\d+)', result.stdout)
+        if not width_match or not height_match:
+            return None
+        width = int(width_match.group(1))
+        height = int(height_match.group(1))
+        if width <= 100 or height <= 100:
+            return None
+        return width, height
+
+    def _visible_firefox_windows(self, env: dict[str, str]) -> list[dict[str, object]]:
+        windows: list[dict[str, object]] = []
+        for window_id in self._xdotool_search(['--class', 'firefox'], env):
+            geometry = self._x_window_geometry(window_id, env)
+            if geometry is None:
+                continue
+            width, height = geometry
+            windows.append({
+                'id': window_id,
+                'title': self._xdotool_window_name(window_id, env),
+                'width': width,
+                'height': height,
+                'area': width * height,
+            })
+        return windows
+
+    def _visible_firefox_window_count(self, env: dict[str, str]) -> int:
+        display = env.get('DISPLAY') or self._display()
+        try:
+            return _viewable_windows(display)
+        except Exception:
+            return len(self._visible_firefox_windows(env))
+
+    @staticmethod
+    def _close_x_window(window_id: str, env: dict[str, str]) -> bool:
+        try:
+            result = subprocess.run(
+                ['xdotool', 'windowclose', window_id],
+                capture_output=True,
+                text=True,
+                timeout=3,
+                env=env,
+            )
+        except Exception:
+            return False
+        if result.returncode == 0:
+            time.sleep(0.3)
+            return True
+        return False
+
     def _focus_platform_firefox_for_attach(self, env: dict[str, str]) -> bool:
         window_ids = self._xdotool_search(['--onlyvisible', '--class', 'Firefox'], env)
         for window_id in reversed(window_ids):
@@ -3971,6 +4035,79 @@ class PerplexityConsultationDriver(_PerplexityInlineBase):
             'download_timeout': timeout,
         }
 
+    @staticmethod
+    def _markdown_download_answer_region(content: str) -> str:
+        text = (content or '').strip()
+        if not text:
+            return ''
+        probe = text[:5000].lower()
+        if (
+            'r2cdn.perplexity.ai/pplx-full-logo' not in probe
+            or 'perplexity deep research request' not in probe
+            or '## output contract' not in probe
+        ):
+            return text
+        contract_pos = probe.find('## output contract')
+        search_start = contract_pos if contract_pos >= 0 else 0
+        markers = (
+            '\nI now have all the information I need.',
+            '\nI have all the information I need.',
+            '\nI now have the information I need.',
+            '\n***\n\n# ',
+        )
+        starts = [
+            pos + (1 if marker.startswith('\n') else 0)
+            for marker in markers
+            if (pos := text.find(marker, search_start)) >= 0
+        ]
+        if not starts:
+            return text
+        return text[min(starts):].strip()
+
+    def _cleanup_markdown_download_popup(
+        self,
+        baseline_window_ids: set[str],
+        *,
+        timeout: float = 3.0,
+    ) -> tuple[bool, dict[str, object]]:
+        env = self._dialog_env()
+        baseline = {str(window_id) for window_id in baseline_window_ids if window_id}
+        windows = self._visible_firefox_windows(env)
+        evidence: dict[str, object] = {
+            'markdown_download_baseline_firefox_window_ids': sorted(baseline),
+            'markdown_download_visible_firefox_windows_before_cleanup': len(windows),
+            'markdown_download_firefox_windows_before_cleanup': windows,
+        }
+        if len(windows) > 1:
+            candidates = [window for window in windows if str(window.get('id') or '') not in baseline]
+            if not candidates:
+                keep = max(windows, key=lambda window: int(window.get('area') or 0))
+                candidates = [window for window in windows if window is not keep]
+            closed: list[str] = []
+            failed: list[str] = []
+            for window in sorted(candidates, key=lambda item: int(item.get('area') or 0)):
+                window_id = str(window.get('id') or '')
+                if not window_id:
+                    continue
+                if self._close_x_window(window_id, env):
+                    closed.append(window_id)
+                else:
+                    failed.append(window_id)
+            evidence['markdown_download_popup_closed_window_ids'] = closed
+            evidence['markdown_download_popup_close_failed_window_ids'] = failed
+        else:
+            evidence['markdown_download_popup_closed_window_ids'] = []
+            evidence['markdown_download_popup_close_failed_window_ids'] = []
+
+        deadline = time.monotonic() + max(float(timeout), 0.1)
+        visible_after = self._visible_firefox_window_count(env)
+        while visible_after != 1 and time.monotonic() < deadline:
+            time.sleep(0.25)
+            visible_after = self._visible_firefox_window_count(env)
+        evidence['markdown_download_visible_firefox_windows_after_cleanup'] = visible_after
+        evidence['markdown_download_popup_cleanup_timeout_seconds'] = timeout
+        return visible_after == 1, evidence
+
     def _activate_markdown_download_item(
         self,
         trigger_key: str,
@@ -4024,6 +4161,9 @@ class PerplexityConsultationDriver(_PerplexityInlineBase):
         result: ConsultationResult,
         attempts: list[dict[str, object]],
     ) -> bool:
+        env = self._dialog_env()
+        baseline_windows = self._visible_firefox_windows(env)
+        baseline_window_ids = {str(window.get('id') or '') for window in baseline_windows}
         before = self._markdown_download_state()
         for trigger_key, item_key in (
             ('more_actions', 'export_markdown_item'),
@@ -4035,8 +4175,33 @@ class PerplexityConsultationDriver(_PerplexityInlineBase):
                 continue
             content, download_evidence = self._read_new_markdown_download(before)
             attempt.update(download_evidence)
+            cleanup_ok, cleanup_evidence = self._cleanup_markdown_download_popup(
+                baseline_window_ids,
+            )
+            download_evidence.update(cleanup_evidence)
+            attempt.update(cleanup_evidence)
+            if not cleanup_ok:
+                result.add_step(
+                    'extract_primary', False,
+                    'Perplexity Markdown download left extra visible Firefox windows open',
+                    target_key='markdown_download',
+                    markdown_download_attempts=attempts,
+                    **download_evidence,
+                )
+                return False
             if not content:
                 continue
+            answer_region = self._markdown_download_answer_region(content)
+            if not answer_region:
+                continue
+            if answer_region != content:
+                download_evidence.update(
+                    markdown_download_stripped_echo=True,
+                    markdown_download_raw_characters=len(content),
+                    markdown_download_answer_characters=len(answer_region),
+                )
+                attempt.update(download_evidence)
+            content = answer_region
             return self._accept_extracted_content(
                 content,
                 request,
@@ -4074,6 +4239,12 @@ class PerplexityConsultationDriver(_PerplexityInlineBase):
         #     intro stub there, so report-card MUST win when both are present)
         #   - inline answer (no report-card) -> copy_button (the inline answer is the
         #     full content)
+        # Observed DR sub-shapes:
+        #   - Zapier b2a1859e: copy_contents_button never renders; Markdown export
+        #     is the extraction path.
+        #   - Cursor 92b7d26b: copy_contents_button can render late; during the
+        #     90s window copy_button may be present but produce an empty clipboard,
+        #     so empty copy_button must continue to Markdown export.
         report_card_readiness: dict[str, object] | None = None
         if is_deep_research:
             snap, target_key, target, report_card_readiness = self._deep_research_copy_target()
@@ -4175,6 +4346,16 @@ class PerplexityConsultationDriver(_PerplexityInlineBase):
             )
 
         markdown_download_attempts: list[dict[str, object]] = []
+        if is_deep_research:
+            markdown_download_attempts.append({
+                'fallback_after_target_key': target_key,
+                'fallback_reason': 'empty_clipboard',
+                'deep_research_render_shape': (
+                    'copy_button_empty_clipboard_after_copy_contents_timeout'
+                    if target_key == 'copy_button'
+                    else 'copy_contents_empty_clipboard'
+                ),
+            })
         if is_deep_research and self._extract_via_markdown_download(
             request,
             result,

--- a/tests/test_perplexity_markdown_download.py
+++ b/tests/test_perplexity_markdown_download.py
@@ -1,0 +1,267 @@
+from consultation_v2.platforms.perplexity.driver import PerplexityConsultationDriver
+from consultation_v2.types import (
+    Choice,
+    ConsultationRequest,
+    ConsultationResult,
+    ElementRef,
+    Snapshot,
+)
+
+
+PRODUCTION_MARKDOWN_SHAPE = """<img src="https://r2cdn.perplexity.ai/pplx-full-logo-primary-dark%402x.png" style="height:64px;margin-right:32px"/>
+
+# \\# Perplexity Deep Research Request - Zapier / Staff Engineer, Backend, Revenue
+
+Generated: 2026-07-14T14:31:34+00:00
+Opportunity id: `22fc095b9b0f3d15`
+
+## ISMA query seeds (derive concrete phrasings)
+
+```json
+{
+  "company_terms": [
+    "Zapier",
+    "Staff"
+  ]
+}
+```
+
+## Output contract (REQUIRED - machine-ingested, do not omit)
+
+End the report with ONE fenced ```json code block (it must be the LAST fenced block in the reply) of exactly this shape:
+
+```
+{
+  "summary": "2-4 sentences: what the company does, stage/scale, hiring context",
+  "product_summary": "what the product actually is, technically",
+  "mission": "their stated mission, or [Unknown]",
+  "values_summary": "citable values stance with source, or [Unknown]",
+  "comp_signals": "comp band / equity signals found, or [Unknown]",
+  "red_flags": ["each flag as one string; empty list if none"],
+  "resonance_mode": "FOUNDER|PRODUCT|VALUES|GENERIC_TECHNICAL",
+  "values_signal": {"axes": [], "strongest_genuine_axis": "NONE", "overlap_with_jesse": "NONE", "values_beat_eligible": false, "cannot_lie_note": "why eligible or not"},
+  "company_application_site": "the company's own ATS/application URL"
+}
+```
+
+Rules: label anything not directly sourced as [Unknown] - never invent. resonance_mode is GENERIC_TECHNICAL unless a citable, specific, action-backed resonance exists.
+
+I now have all the information I need. Let me compose the full report now.
+
+***
+
+# Zapier - Staff Engineer, Backend, Revenue
+
+## Company Overview
+
+Observed report body.
+
+```json
+{
+  "summary": "Zapier is a fully remote workflow automation platform.",
+  "product_summary": "A no-code/low-code automation platform connecting SaaS apps.",
+  "mission": "Make automation work for everyone.",
+  "values_summary": "Published values include Build the Robot.",
+  "comp_signals": "$211K-$316K base.",
+  "red_flags": [],
+  "resonance_mode": "VALUES",
+  "values_signal": {"axes": [], "strongest_genuine_axis": "NONE", "overlap_with_jesse": "NONE", "values_beat_eligible": false, "cannot_lie_note": "fixture"},
+  "company_application_site": "https://jobs.ashbyhq.com/zapier/1767482d-de23-460c-80eb-6d0a3caa72ab"
+}
+```
+"""
+
+
+def test_markdown_download_strips_echoed_request_before_report_json():
+    cleaned = PerplexityConsultationDriver._markdown_download_answer_region(
+        PRODUCTION_MARKDOWN_SHAPE,
+    )
+
+    assert cleaned.startswith("I now have all the information I need.")
+    assert "# \\# Perplexity Deep Research Request" not in cleaned
+    assert '"company_terms"' not in cleaned
+    assert '"summary": "2-4 sentences' not in cleaned
+    assert cleaned.count("```json") == 1
+    assert '"summary": "Zapier is a fully remote workflow automation platform."' in cleaned
+
+
+def test_markdown_download_cleanup_closes_spawned_firefox_popup(monkeypatch):
+    driver = PerplexityConsultationDriver()
+    seen_commands = []
+
+    def fake_search(args, env, timeout=2):
+        seen_commands.append(tuple(args))
+        if args == ['--class', 'firefox']:
+            return ['main-window', 'download-popup']
+        return []
+
+    def fake_window_name(window_id, env):
+        return {
+            'main-window': 'Zapier - Perplexity',
+            'download-popup': 'Firefox',
+        }[window_id]
+
+    def fake_window_geometry(window_id, env):
+        return {
+            'main-window': (1280, 900),
+            'download-popup': (496, 340),
+        }[window_id]
+
+    closed = []
+
+    def fake_close(window_id, env):
+        closed.append(window_id)
+        return True
+
+    visible_counts = iter([2, 1])
+
+    monkeypatch.setattr(driver, '_xdotool_search', fake_search)
+    monkeypatch.setattr(driver, '_xdotool_window_name', fake_window_name)
+    monkeypatch.setattr(driver, '_x_window_geometry', fake_window_geometry)
+    monkeypatch.setattr(driver, '_close_x_window', fake_close)
+    monkeypatch.setattr(
+        driver,
+        '_visible_firefox_window_count',
+        lambda env: next(visible_counts),
+    )
+
+    ok, evidence = driver._cleanup_markdown_download_popup({'main-window'})
+
+    assert ok is True
+    assert closed == ['download-popup']
+    assert evidence['markdown_download_popup_closed_window_ids'] == ['download-popup']
+    assert evidence['markdown_download_visible_firefox_windows_after_cleanup'] == 1
+    assert ('--class', 'firefox') in seen_commands
+
+
+def test_markdown_download_cleanup_fails_loud_when_popup_remains(monkeypatch):
+    driver = PerplexityConsultationDriver()
+
+    monkeypatch.setattr(
+        driver,
+        '_visible_firefox_windows',
+        lambda env: [
+            {
+                'id': 'main-window',
+                'title': 'Zapier - Perplexity',
+                'width': 1280,
+                'height': 900,
+                'area': 1152000,
+            },
+            {
+                'id': 'download-popup',
+                'title': 'Firefox',
+                'width': 496,
+                'height': 340,
+                'area': 168640,
+            },
+        ],
+    )
+    monkeypatch.setattr(driver, '_close_x_window', lambda window_id, env: False)
+    monkeypatch.setattr(driver, '_visible_firefox_window_count', lambda env: 2)
+
+    ok, evidence = driver._cleanup_markdown_download_popup(
+        {'main-window'},
+        timeout=0.1,
+    )
+
+    assert ok is False
+    assert evidence['markdown_download_popup_close_failed_window_ids'] == [
+        'download-popup',
+    ]
+    assert evidence['markdown_download_visible_firefox_windows_after_cleanup'] == 2
+
+
+def test_deep_research_empty_copy_button_clipboard_reaches_markdown_download(
+    monkeypatch,
+):
+    driver = PerplexityConsultationDriver()
+    copy_button = ElementRef(
+        key='copy_button',
+        name='Copy',
+        role='push button',
+        x=10,
+        y=20,
+    )
+    snap = Snapshot(
+        platform='perplexity',
+        url='https://www.perplexity.ai/search/92b7d26b',
+        mapped={'copy_button': [copy_button]},
+        raw_count=10,
+    )
+
+    class FakeRuntime:
+        def __init__(self):
+            self.clicked = []
+
+        def scroll_element_into_view(self, target):
+            return True
+
+        def write_clipboard(self, _text):
+            return None
+
+        def click(self, target, strategy=None):
+            self.clicked.append((target.key, strategy))
+            return True
+
+    runtime = FakeRuntime()
+    driver.runtime = runtime
+
+    request = ConsultationRequest(
+        platform='perplexity',
+        message='research',
+        selections={'mode': Choice('deep_research')},
+    )
+    result = ConsultationResult(platform='perplexity', request=request)
+    markdown_attempts_seen = []
+
+    def fake_markdown_download(_request, result_arg, attempts):
+        markdown_attempts_seen.extend(attempts)
+        result_arg.response_text = 'markdown fallback answer'
+        result_arg.add_step(
+            'extract_primary',
+            True,
+            'markdown fallback reached',
+            target_key='markdown_download',
+            markdown_download_attempts=attempts,
+        )
+        return True
+
+    monkeypatch.setattr(driver, '_ensure_answer_thread', lambda _result: True)
+    monkeypatch.setattr(
+        driver,
+        '_deep_research_copy_target',
+        lambda: (
+            snap,
+            'copy_button',
+            copy_button,
+            {
+                'waited_for': 'copy_contents_button',
+                'matched': False,
+                'selected': 'copy_button',
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        driver,
+        '_read_clipboard_until_nonempty',
+        lambda: ('', {'clipboard_reads': 14}),
+    )
+    monkeypatch.setattr(
+        driver,
+        '_extract_via_markdown_download',
+        fake_markdown_download,
+    )
+
+    assert driver.extract_primary(request, result) is True
+
+    assert runtime.clicked == [('copy_button', 'atspi_only')]
+    assert markdown_attempts_seen
+    assert markdown_attempts_seen[0]['fallback_after_target_key'] == 'copy_button'
+    assert markdown_attempts_seen[0]['fallback_reason'] == 'empty_clipboard'
+    assert (
+        markdown_attempts_seen[0]['deep_research_render_shape']
+        == 'copy_button_empty_clipboard_after_copy_contents_timeout'
+    )
+    assert result.steps[-1].success is True
+    assert result.steps[-1].evidence['target_key'] == 'markdown_download'


### PR DESCRIPTION
Fixes three production-observed failure modes of the DR extract fallback: (1) markdown-download exported the whole thread (echoed request + EMPTY contract-template above the real one — first-match parse landmine); now answer-region-only, triple-marker-gated, fails toward keep-too-much. (2) The download popup dirtied the display for the next run; now closed + verified back to exactly-1-window, fail-loud. (3) DR copy_button-empty terminal-failed before reaching the markdown tier (Cursor); now continues down the chain, DR-guarded, non-DR unchanged. Render sub-shapes named: Zapier=copy_contents never renders; Cursor=renders late. Dual r5 exec-verified through three delta rounds. Owner-gate: merged on proven-live-defect-vs-triple-audited-fix risk inversion; fallback validation converts to a BINDING production-watch (first natural trigger, taeys-hands validates checks 1-3 live, full-stop on misbehavior); happy path corroborated clean 2x from the fix worktree. 🤖 Generated with [Claude Code](https://claude.com/claude-code)