### PR TITLE
Perplexity attach: readiness-poll + Computer-onboarding dismissal + optional identity attach

### DIFF
--- a/consultation_v2/cli.py
+++ b/consultation_v2/cli.py
@@ -61,6 +61,11 @@ def build_parser() -> argparse.ArgumentParser:
         action='store_true',
         help='Attach only caller-provided files; do not prepend FAMILY_KERNEL or platform IDENTITY.',
     )
+    parser.add_argument(
+        '--skip-identity-attachment',
+        action='store_true',
+        help='Send the prompt without an identity package; caller attachments, if any, are still attached.',
+    )
     parser.add_argument('--session-type', default=None)
     parser.add_argument('--purpose', default=None)
     parser.add_argument('--requester', default=None,
@@ -146,6 +151,30 @@ def _resolve_identity_for_dry_run(
     request: ConsultationRequest,
 ) -> tuple[ConsultationRequest, dict[str, Any]]:
     caller_attachments = list(request.attachments)
+    if request.no_identity and not request.attach_identity:
+        raise IdentityError(
+            'no_identity and attach_identity=False are mutually exclusive; use '
+            'one explicit identity mode for this consultation.'
+        )
+    if not request.attach_identity:
+        provenance = (
+            validate_caller_attachments(caller_attachments)
+            if caller_attachments else []
+        )
+        return (
+            replace(
+                request,
+                attachments=caller_attachments,
+                caller_attachment_provenance=provenance,
+            ),
+            {
+                'mode': 'identity_attachment_skipped',
+                'package_paths': caller_attachments,
+                'caller_attachment_provenance': [
+                    item.serializable() for item in provenance
+                ],
+            },
+        )
     if request.no_identity:
         if not caller_attachments:
             raise IdentityError(
@@ -222,6 +251,7 @@ def _request_record(request: ConsultationRequest) -> dict[str, Any]:
         'store_enabled': request.store_enabled,
         'external_store_enabled': storage_policy.external_store_enabled(request),
         'no_identity': request.no_identity,
+        'attach_identity': request.attach_identity,
         'session_type': request.session_type,
         'purpose': request.purpose,
         'requester': request.requester,
@@ -240,6 +270,8 @@ def main() -> int:
         selections = parse_select_args(args.platform, list(args.select or []))
     except ValueError as exc:
         parser.error(str(exc))
+    if args.no_identity and args.skip_identity_attachment:
+        parser.error('--no-identity and --skip-identity-attachment are mutually exclusive')
     if args.no_identity and not args.attach:
         parser.error('--no-identity requires at least one --attach file')
     request = ConsultationRequest(
@@ -253,6 +285,7 @@ def main() -> int:
         no_neo4j=args.no_neo4j,
         store_enabled=args.store,
         no_identity=args.no_identity,
+        attach_identity=not args.skip_identity_attachment,
         session_type=args.session_type,
         purpose=args.purpose,
         requester=args.requester,

--- a/consultation_v2/orchestrator.py
+++ b/consultation_v2/orchestrator.py
@@ -128,7 +128,23 @@ def run_consultation(request: ConsultationRequest) -> ConsultationResult:
     consolidated_path = ''
     package_paths = []
     identity_mode = 'identity_consolidated'
-    if request.no_identity:
+    if request.no_identity and not request.attach_identity:
+        raise IdentityError(
+            'no_identity and attach_identity=False are mutually exclusive; use '
+            'one explicit identity mode for this consultation.'
+        )
+    if not request.attach_identity:
+        provenance = (
+            validate_caller_attachments(caller_attachments)
+            if caller_attachments else []
+        )
+        identity_mode = 'identity_attachment_skipped'
+        request = replace(
+            request,
+            attachments=caller_attachments,
+            caller_attachment_provenance=provenance,
+        )
+    elif request.no_identity:
         if not caller_attachments:
             raise IdentityError(
                 '--no-identity requires at least one --attach file; refusing to '

--- a/consultation_v2/platforms/perplexity/driver.py
+++ b/consultation_v2/platforms/perplexity/driver.py
@@ -2958,11 +2958,16 @@ class PerplexityConsultationDriver(_PerplexityInlineBase):
             )
             if not navigated:
                 return False
+        if not self._dismiss_computer_onboarding(result):
+            return False
+        if target_url:
             if not self.wait_for_page_ready_after_navigation(result):
                 return False
         if not self._wait_for_prompt_ready(result):
             return False
         if not self.apply_selection_plan(request, result):
+            return False
+        if not self._dismiss_computer_onboarding(result):
             return False
         if request.selection_list('connectors'):
             if not self.toggle_connectors(request, result):
@@ -3018,6 +3023,168 @@ class PerplexityConsultationDriver(_PerplexityInlineBase):
             ),
             input_key=input_key,
             snapshot=snap.serializable(),
+        )
+        return verified
+
+    def _computer_onboarding_cfg(self) -> dict[str, Any]:
+        workflow = self.cfg.get('workflow') or {}
+        onboarding = workflow.get('onboarding') if isinstance(workflow, dict) else None
+        cfg = onboarding.get('computer_setup') if isinstance(onboarding, dict) else None
+        if not isinstance(cfg, dict):
+            raise ValueError('Perplexity YAML workflow.onboarding.computer_setup is required')
+        return cfg
+
+    def _computer_onboarding_keys(self, cfg: dict[str, Any], name: str) -> list[str]:
+        raw_keys = cfg.get(name)
+        if not isinstance(raw_keys, list) or not raw_keys:
+            raise ValueError(
+                f'Perplexity YAML workflow.onboarding.computer_setup.{name} '
+                'must be a non-empty key list'
+            )
+        element_map = (self.cfg.get('tree') or {}).get('element_map') or {}
+        keys: list[str] = []
+        for raw_key in raw_keys:
+            key = str(raw_key).strip() if isinstance(raw_key, str) else ''
+            if not key:
+                continue
+            if key not in element_map:
+                raise ValueError(
+                    f'Perplexity onboarding key {key!r} is not declared in tree.element_map'
+                )
+            keys.append(key)
+        if not keys:
+            raise ValueError(
+                f'Perplexity YAML workflow.onboarding.computer_setup.{name} '
+                'must contain at least one declared element key'
+            )
+        return keys
+
+    @staticmethod
+    def _computer_onboarding_dismiss_keys(cfg: dict[str, Any]) -> list[str]:
+        raw_keys = cfg.get('dismiss_keys')
+        if not isinstance(raw_keys, list) or not raw_keys:
+            raise ValueError(
+                'Perplexity YAML workflow.onboarding.computer_setup.dismiss_keys '
+                'must be a non-empty key list'
+            )
+        keys = [
+            str(raw_key).strip()
+            for raw_key in raw_keys
+            if isinstance(raw_key, str) and raw_key.strip()
+        ]
+        if not keys:
+            raise ValueError(
+                'Perplexity YAML workflow.onboarding.computer_setup.dismiss_keys '
+                'must contain at least one key chord'
+            )
+        return keys
+
+    @staticmethod
+    def _computer_onboarding_timeout_seconds(
+        cfg: dict[str, Any],
+        name: str,
+        default_ms: int,
+    ) -> float:
+        value = cfg.get(name, default_ms)
+        try:
+            seconds = float(int(value)) / 1000.0
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f'Perplexity YAML workflow.onboarding.computer_setup.{name} '
+                'must be integer milliseconds'
+            ) from exc
+        return max(seconds, 0.1)
+
+    @staticmethod
+    def _snapshot_has_all(snapshot: Snapshot, keys: Iterable[str]) -> bool:
+        return all(snapshot.has(key) for key in keys)
+
+    def _dismiss_computer_onboarding(
+        self,
+        result: ConsultationResult,
+        *,
+        initial_snapshot: Snapshot | None = None,
+    ) -> bool:
+        cfg = self._computer_onboarding_cfg()
+        marker_keys = self._computer_onboarding_keys(cfg, 'markers')
+        standard_keys = self._computer_onboarding_keys(cfg, 'standard_composer')
+        dismiss_keys = self._computer_onboarding_dismiss_keys(cfg)
+        detect_timeout = self._computer_onboarding_timeout_seconds(
+            cfg, 'detect_timeout_ms', 6000
+        )
+        settle_timeout = self._computer_onboarding_timeout_seconds(
+            cfg, 'settle_ms', 8000
+        )
+        last_snapshot = initial_snapshot
+
+        def classify(snapshot: Snapshot) -> str | None:
+            if self.snapshot_has_any(snapshot, marker_keys):
+                return 'onboarding'
+            if self._snapshot_has_all(snapshot, standard_keys):
+                return 'standard'
+            return None
+
+        observed = classify(last_snapshot) if last_snapshot is not None else None
+        if observed is None:
+            def probe() -> str | None:
+                nonlocal last_snapshot
+                last_snapshot = self.runtime.snapshot()
+                return classify(last_snapshot)
+
+            observed = self.runtime.wait_until(
+                probe,
+                timeout=detect_timeout,
+                interval=0.4,
+            )
+        if observed != 'onboarding':
+            return True
+
+        before_snapshot = last_snapshot or self.runtime.snapshot()
+        self.runtime.focus_firefox()
+        pressed: list[str] = []
+        failed: list[str] = []
+        for dismiss_key in dismiss_keys:
+            if self.runtime.press(dismiss_key):
+                pressed.append(dismiss_key)
+            else:
+                failed.append(dismiss_key)
+            time.sleep(0.2)
+
+        final_snapshot: Snapshot | None = None
+
+        def standard_probe() -> Snapshot | None:
+            nonlocal final_snapshot
+            final_snapshot = self.runtime.snapshot()
+            if self._snapshot_has_all(final_snapshot, standard_keys):
+                return final_snapshot
+            return None
+
+        restored = self.runtime.wait_until(
+            standard_probe,
+            timeout=settle_timeout,
+            interval=0.4,
+        )
+        snapshot = (
+            restored
+            if isinstance(restored, Snapshot)
+            else (final_snapshot or self.runtime.snapshot())
+        )
+        verified = isinstance(restored, Snapshot)
+        result.add_step(
+            'computer_onboarding',
+            verified,
+            (
+                'Dismissed Perplexity Computer onboarding; standard composer restored'
+                if verified else
+                'Perplexity Computer onboarding did not restore the standard composer'
+            ),
+            marker_keys=marker_keys,
+            standard_keys=standard_keys,
+            dismiss_keys=dismiss_keys,
+            pressed_keys=pressed,
+            failed_keys=failed,
+            before_snapshot=before_snapshot.serializable(),
+            snapshot=snapshot.serializable(),
         )
         return verified
 

--- a/consultation_v2/platforms/perplexity/perplexity.yaml
+++ b/consultation_v2/platforms/perplexity/perplexity.yaml
@@ -308,6 +308,17 @@ workflow:
     trigger: attach_trigger
     menu_target: upload_files_item
     open_method: atspi_menu
+  onboarding:
+    computer_setup:
+      markers:
+      - computer_ready
+      standard_composer:
+      - input
+      - attach_trigger
+      dismiss_keys:
+      - Escape
+      detect_timeout_ms: 6000
+      settle_ms: 8000
   connectors:
     # Source toggle workflow: open attach dropdown → click git_connector_item
     # → panel opens in portal → use menu_snapshot() for all source items.

--- a/consultation_v2/types.py
+++ b/consultation_v2/types.py
@@ -63,6 +63,7 @@ class ConsultationRequest:
     no_neo4j: bool = False
     store_enabled: bool = False
     no_identity: bool = False
+    attach_identity: bool = True
     session_type: Optional[str] = None
     purpose: Optional[str] = None
     requester: Optional[str] = None
@@ -133,7 +134,16 @@ class ConsultationRequest:
         which irreversible turn this is."""
         session_target = self.session_url or 'new'
         seed = f'{self.platform}\x1f{session_target}\x1f{self.prompt_hash()}'
-        if self.no_identity:
+        if not self.attach_identity:
+            provenance = self.caller_attachment_provenance or []
+            if provenance:
+                attachment_seed = '\x1e'.join(
+                    f'{prov.path}\x1d{prov.sha256}' for prov in provenance
+                )
+            else:
+                attachment_seed = '\x1e'.join(self.attachments)
+            seed = f'{seed}\x1fidentity_attachment_skipped\x1f{attachment_seed}'
+        elif self.no_identity:
             provenance = self.caller_attachment_provenance or []
             if provenance:
                 attachment_seed = '\x1e'.join(
@@ -299,6 +309,7 @@ class ConsultationResult:
                 'no_neo4j': self.request.no_neo4j,
                 'store_enabled': self.request.store_enabled,
                 'no_identity': self.request.no_identity,
+                'attach_identity': self.request.attach_identity,
                 'session_type': self.request.session_type,
                 'purpose': self.request.purpose,
             },

--- a/tests/test_perplexity_onboarding_identity.py
+++ b/tests/test_perplexity_onboarding_identity.py
@@ -1,0 +1,133 @@
+import hashlib
+
+import pytest
+
+from consultation_v2.cli import _request_record, _resolve_identity_for_dry_run
+from consultation_v2.identity import IdentityError
+from consultation_v2.platforms.perplexity.driver import PerplexityConsultationDriver
+from consultation_v2.types import ConsultationRequest, ElementRef, Snapshot
+
+
+class FakeRuntime:
+    def __init__(self, snapshots):
+        self._snapshots = list(snapshots)
+        self.pressed = []
+
+    def snapshot(self):
+        if len(self._snapshots) > 1:
+            return self._snapshots.pop(0)
+        return self._snapshots[0]
+
+    def wait_until(self, probe, *, timeout, interval):
+        for _ in range(8):
+            value = probe()
+            if value:
+                return value
+        return None
+
+    def focus_firefox(self):
+        return True
+
+    def press(self, key):
+        self.pressed.append(key)
+        return True
+
+
+def _element(key):
+    return ElementRef(key=key, name=key, role='push button', x=1, y=1)
+
+
+def _snapshot(*keys):
+    return Snapshot(
+        platform='perplexity',
+        url='https://www.perplexity.ai/',
+        mapped={key: [_element(key)] for key in keys},
+        raw_count=len(keys),
+    )
+
+
+def _driver_with_snapshots(*snapshots):
+    driver = PerplexityConsultationDriver()
+    driver.runtime = FakeRuntime(snapshots)
+    return driver
+
+
+def _result():
+    return _driver_with_snapshots(_snapshot('input', 'attach_trigger')).result(
+        ConsultationRequest(platform='perplexity', message='hello')
+    )
+
+
+def test_computer_onboarding_dismisses_and_verifies_standard_composer():
+    driver = _driver_with_snapshots(
+        _snapshot('computer_ready'),
+        _snapshot('input', 'attach_trigger'),
+    )
+    result = _result()
+
+    assert driver._dismiss_computer_onboarding(result) is True
+
+    assert driver.runtime.pressed == ['Escape']
+    step = result.steps[-1]
+    assert step.step == 'computer_onboarding'
+    assert step.success is True
+    assert step.evidence['standard_keys'] == ['input', 'attach_trigger']
+
+
+def test_computer_onboarding_fails_closed_when_standard_composer_does_not_return():
+    driver = _driver_with_snapshots(
+        _snapshot('computer_ready'),
+        _snapshot('computer_ready'),
+    )
+    result = _result()
+
+    assert driver._dismiss_computer_onboarding(result) is False
+
+    assert driver.runtime.pressed == ['Escape']
+    step = result.steps[-1]
+    assert step.step == 'computer_onboarding'
+    assert step.success is False
+
+
+def test_skip_identity_attachment_request_allows_zero_attachments_in_dry_run():
+    request = ConsultationRequest(
+        platform='perplexity',
+        message='company research only',
+        attach_identity=False,
+    )
+
+    resolved, identity = _resolve_identity_for_dry_run(request)
+
+    assert resolved.attachments == []
+    assert identity['mode'] == 'identity_attachment_skipped'
+    assert identity['package_paths'] == []
+    assert _request_record(resolved)['attach_identity'] is False
+
+
+def test_no_identity_still_requires_a_caller_attachment():
+    request = ConsultationRequest(
+        platform='perplexity',
+        message='caller-only still needs a packet',
+        no_identity=True,
+    )
+
+    with pytest.raises(IdentityError):
+        _resolve_identity_for_dry_run(request)
+
+
+def test_skip_identity_attachment_changes_only_the_new_request_id_mode():
+    default_request = ConsultationRequest(platform='perplexity', message='same prompt')
+    skip_request = ConsultationRequest(
+        platform='perplexity',
+        message='same prompt',
+        attach_identity=False,
+    )
+    seed = (
+        f'{default_request.platform}\x1fnew\x1f'
+        f'{default_request.prompt_hash()}'
+    )
+
+    assert default_request.request_id() == hashlib.sha256(
+        seed.encode('utf-8')
+    ).hexdigest()[:32]
+    assert skip_request.request_id() != default_request.request_id()


### PR DESCRIPTION
Three-part attach fix (production: attach race on the Computer-mode composer, 2x): wait_for_key(upload_files_item) readiness-poll replaces the fixed-settle race (bounded, fail-loud); YAML-driven Set-up-Computer dismissal (bounded, fail-loud, zero-cost when absent); --skip-identity-attachment for careers/research DRs (opt-in only — the Family default proven preserved through every layer by both r5 auditors). Owner oracle: attach-optional DEFINITIVE PASS live (careers DR clean, zero upload attempt); default-attach regression PASS live; dismiss + Computer-mode poll stress convert to a binding production-watch (onboarding currently self-cleared). Dual r5 ENDORSE. 🤖 Generated with [Claude Code](https://claude.com/claude-code)