### PR TITLE
gemini: deselect Deep Research on non-DR path before send (taeys-hands defect)

### DIFF
--- a/consultation_v2/platforms/gemini/driver.py
+++ b/consultation_v2/platforms/gemini/driver.py
@@ -2980,6 +2980,8 @@ class GeminiConsultationDriver(_GeminiInlineBase):
             return False
         if not self.enter_prompt(request, result):
             return False
+        if not self._ensure_non_deep_research_tool_state(request, result):
+            return False
         # Idempotent send seam (FLOW §8): guarded_send reads durable run-state
         # first and RESUMES a landed send instead of re-sending; otherwise it
         # performs the real send via self.send_prompt and checkpoints submitted.
@@ -3135,6 +3137,130 @@ class GeminiConsultationDriver(_GeminiInlineBase):
                         snapshot=verify_snap.serializable())
         return verified
 
+    def _resolved_mode_is_deep_research(self, request: ConsultationRequest) -> bool:
+        mode = str(self._resolved_selection_value(request, 'mode', '') or '').strip().lower()
+        if mode != 'deep_research':
+            return False
+
+        requested_mode = (
+            request.selection_value('mode', None)
+            if 'mode' in (request.selections or {})
+            else None
+        )
+        if str(requested_mode or '').strip().lower() in {'deep_research', 'default'}:
+            return True
+
+        requested_model = (
+            request.selection_value('model', None)
+            if 'model' in (request.selections or {})
+            else None
+        )
+        if str(requested_model or '').strip().lower() in {'fast', 'pro', 'thinking'}:
+            return False
+        return True
+
+    def _resolved_mode_label(self, request: ConsultationRequest) -> str:
+        mode = str(self._resolved_selection_value(request, 'mode', '') or '').strip().lower()
+        if mode == 'deep_research' and not self._resolved_mode_is_deep_research(request):
+            return 'none'
+        return mode
+
+    def _wait_for_deep_research_inactive(
+        self,
+        *,
+        timeout: float = 6.0,
+        interval: float = 0.4,
+    ) -> Snapshot:
+        last_snapshot: Snapshot | None = None
+
+        def _probe() -> Snapshot | None:
+            nonlocal last_snapshot
+            last_snapshot = self.runtime.snapshot()
+            if not self.validation_passes(last_snapshot, 'deep_research_active'):
+                return last_snapshot
+            return None
+
+        matched = self.runtime.wait_until(_probe, timeout=timeout, interval=interval)
+        if isinstance(matched, Snapshot):
+            return matched
+        return last_snapshot or self.runtime.snapshot()
+
+    def _deep_research_deselect_evidence(self, request: ConsultationRequest) -> dict[str, object]:
+        return {
+            'mode': self._resolved_mode_label(request),
+            'resolved_mode': self._resolved_selection_value(request, 'mode', ''),
+            'requested_model': (
+                request.selection_value('model', None)
+                if 'model' in (request.selections or {})
+                else None
+            ),
+            'requested_mode': (
+                request.selection_value('mode', None)
+                if 'mode' in (request.selections or {})
+                else None
+            ),
+        }
+
+    def _ensure_non_deep_research_tool_state(
+        self, request: ConsultationRequest, result: ConsultationResult
+    ) -> bool:
+        if self._resolved_mode_is_deep_research(request):
+            return True
+
+        evidence = self._deep_research_deselect_evidence(request)
+        initial_snap = self.runtime.snapshot()
+        active_before = self.validation_passes(initial_snap, 'deep_research_active')
+        deselect = self.find_first(initial_snap, 'tool_deselect_deep_research')
+        if not deselect:
+            result.add_step(
+                'deep_research_deselect',
+                not active_before,
+                (
+                    'Gemini Deep Research already inactive for non-Deep-Research send'
+                    if not active_before
+                    else 'Gemini Deep Research active indicator was not mapped for deselect'
+                ),
+                **evidence,
+                active_before=active_before,
+                deselect_present=False,
+                active_after=active_before,
+                snapshot=initial_snap.serializable(),
+            )
+            return not active_before
+
+        clicked = self.runtime.click(deselect, strategy='atspi_first')
+        if not clicked:
+            result.add_step(
+                'deep_research_deselect',
+                False,
+                'Gemini Deep Research deselect click failed for non-Deep-Research send',
+                **evidence,
+                active_before=active_before,
+                deselect_present=True,
+                active_after=active_before,
+                snapshot=initial_snap.serializable(),
+            )
+            return False
+
+        verify_snap = self._wait_for_deep_research_inactive()
+        active_after = self.validation_passes(verify_snap, 'deep_research_active')
+        result.add_step(
+            'deep_research_deselect',
+            not active_after,
+            (
+                'Gemini Deep Research deselected for non-Deep-Research send'
+                if not active_after
+                else 'Gemini Deep Research stayed active after deselect click'
+            ),
+            **evidence,
+            active_before=active_before,
+            deselect_present=True,
+            clicked=True,
+            active_after=active_after,
+            snapshot=verify_snap.serializable(),
+        )
+        return not active_after
+
     @staticmethod
     def _element_evidence(element: ElementRef | None) -> dict[str, object] | None:
         if not element:
@@ -3272,10 +3398,7 @@ class GeminiConsultationDriver(_GeminiInlineBase):
         # report. Generous timeout: plan generation can take ~1 min. Gated on the
         # deep_research mode so single-step modes (deep_think/normal/…) are
         # unaffected. (Jesse 2026-06-15: prior runs harvested only the plan.)
-        is_dr_send = (
-            str(self._resolved_selection_value(request, 'mode', '') or '').strip().lower()
-            == 'deep_research'
-        )
+        is_dr_send = self._resolved_mode_is_deep_research(request)
         start_research_evidence: dict[str, object] = {}
         if is_dr_send:
             post_send_clicked, start_research_evidence = self._launch_deep_research_from_plan()
@@ -3365,7 +3488,7 @@ class GeminiConsultationDriver(_GeminiInlineBase):
     ) -> str:
         selected = (
             mode if mode is not None
-            else self._resolved_selection_value(request, 'mode', '')
+            else self._resolved_mode_label(request)
         )
         return str(selected or '').strip().lower()
 
@@ -3660,10 +3783,7 @@ class GeminiConsultationDriver(_GeminiInlineBase):
         # full report is copied via the panel's "Share & Export" -> "Copy" (a
         # menu item in the popover), NOT the chat-bubble Copy push button.
         # Proven 2026-06-15: 36KB report via this path vs 89 chars via the bubble.
-        if (
-            str(self._resolved_selection_value(request, 'mode', '') or '').strip().lower()
-            == 'deep_research'
-        ):
+        if self._resolved_mode_is_deep_research(request):
             # Resolve Share & Export from a LIVE app-root scan (no cache-clear) so
             # the atspi_obj is fresh — a stale snapshot ref do_action's True but
             # doesn't open the popover (p8 2026-06-21). atspi_only = do_action(0)
@@ -3747,7 +3867,7 @@ class GeminiConsultationDriver(_GeminiInlineBase):
     def extract_additional(
         self, request: ConsultationRequest, result: ConsultationResult
     ) -> bool:
-        mode = str(self._resolved_selection_value(request, 'mode', '') or '').strip().lower()
+        mode = self._resolved_mode_label(request)
         # For Deep Research, extract_primary already captured the full report via
         # Share & Export -> Copy; re-running that path here would only duplicate it.
         if mode == 'deep_research':

--- a/tests/test_gemini_deep_research_deselect.py
+++ b/tests/test_gemini_deep_research_deselect.py
@@ -1,0 +1,149 @@
+from consultation_v2.planner import build_selection_plan
+from consultation_v2.platforms.gemini.driver import GeminiConsultationDriver
+from consultation_v2.types import (
+    Choice,
+    ConsultationRequest,
+    ConsultationResult,
+    ElementRef,
+    Snapshot,
+)
+
+
+class FakeRuntime:
+    def __init__(self, snapshots, calls=None, click_ok=True):
+        self._snapshots = list(snapshots)
+        self.calls = calls if calls is not None else []
+        self.click_ok = click_ok
+
+    def snapshot(self):
+        if len(self._snapshots) > 1:
+            return self._snapshots.pop(0)
+        return self._snapshots[0]
+
+    def wait_until(self, probe, *, timeout, interval):
+        last = None
+        for _ in range(8):
+            last = probe()
+            if last:
+                return last
+        return last
+
+    def click(self, target, strategy=None):
+        self.calls.append(f'click:{target.key}:{strategy}')
+        return self.click_ok
+
+    def switch(self):
+        return True
+
+    def current_url(self):
+        return 'https://gemini.google.com/app'
+
+    def navigate(self, _target_url, *, verify_change=False):
+        return True
+
+
+def _deselect_element():
+    return ElementRef(
+        key='tool_deselect_deep_research',
+        name='Deselect Deep research',
+        role='push button',
+        x=10,
+        y=20,
+    )
+
+
+def _snapshot(active=False):
+    mapped = {}
+    if active:
+        mapped['tool_deselect_deep_research'] = [_deselect_element()]
+    return Snapshot(
+        platform='gemini',
+        url='https://gemini.google.com/app',
+        mapped=mapped,
+        raw_count=1 if active else 0,
+    )
+
+
+def _driver(runtime):
+    driver = GeminiConsultationDriver()
+    driver.runtime = runtime
+    return driver
+
+
+def _request(**selections):
+    return ConsultationRequest(
+        platform='gemini',
+        message='hello',
+        selections={key: Choice(value) for key, value in selections.items()},
+    )
+
+
+def _result(request):
+    return ConsultationResult(platform='gemini', request=request)
+
+
+def test_non_deep_research_setup_deselects_deep_research_before_send(monkeypatch):
+    calls = []
+    runtime = FakeRuntime([_snapshot(), _snapshot(active=True), _snapshot()], calls)
+    driver = _driver(runtime)
+    request = _request(model='pro')
+    result = _result(request)
+
+    monkeypatch.setattr(driver, 'wait_for_page_ready_after_navigation', lambda _result: True)
+    monkeypatch.setattr(driver, 'attach_files', lambda _request, _result: calls.append('attach') or True)
+    monkeypatch.setattr(driver, 'enter_prompt', lambda _request, _result: calls.append('prompt') or True)
+    monkeypatch.setattr(driver, 'guarded_send', lambda _request, _result: calls.append('send') or True)
+
+    def apply_selection_plan(request_arg, _result):
+        driver._current_selection_plan = build_selection_plan(request_arg)
+        calls.append('select')
+        return True
+
+    monkeypatch.setattr(driver, 'apply_selection_plan', apply_selection_plan)
+
+    assert driver.setup_and_send(request, result) is True
+
+    assert driver._resolved_mode_label(request) == 'none'
+    assert calls == [
+        'select',
+        'attach',
+        'prompt',
+        'click:tool_deselect_deep_research:atspi_first',
+        'send',
+    ]
+    step = result.steps[-1]
+    assert step.step == 'deep_research_deselect'
+    assert step.success is True
+    assert step.evidence['active_before'] is True
+    assert step.evidence['active_after'] is False
+
+
+def test_non_deep_research_fails_closed_when_deselect_does_not_clear():
+    runtime = FakeRuntime([_snapshot(active=True), _snapshot(active=True)])
+    driver = _driver(runtime)
+    request = _request(model='thinking')
+    driver._current_selection_plan = build_selection_plan(request)
+    result = _result(request)
+
+    assert driver._ensure_non_deep_research_tool_state(request, result) is False
+
+    assert runtime.calls == ['click:tool_deselect_deep_research:atspi_first']
+    step = result.steps[-1]
+    assert step.step == 'deep_research_deselect'
+    assert step.success is False
+    assert step.evidence['active_before'] is True
+    assert step.evidence['active_after'] is True
+
+
+def test_deep_research_mode_keeps_deep_research_selected():
+    runtime = FakeRuntime([_snapshot(active=True)])
+    driver = _driver(runtime)
+    request = _request(model='pro', mode='deep_research')
+    driver._current_selection_plan = build_selection_plan(request)
+    result = _result(request)
+
+    assert driver._resolved_mode_label(request) == 'deep_research'
+    assert driver._ensure_non_deep_research_tool_state(request, result) is True
+
+    assert runtime.calls == []
+    assert result.steps == []


### PR DESCRIPTION
Fixes the taeys-hands 6SIGMA defect: gemini `--select model=pro`/`thinking` dispatches silently ran Deep Research, because new Gemini chats now default the `deep_research` tool ON and the non-DR path never deselected it before send → DR confabulated over the `--attach`.

Root-cause fix (`consultation_v2/platforms/gemini/driver.py`): before send, `_ensure_non_deep_research_tool_state` runs on the **non-DR resolved mode only** (`_resolved_mode_is_deep_research` correctly treats `mode=deep_research` + `model=fast/pro/thinking` as NOT DR) — it clicks `tool_deselect_deep_research`, then `_wait_for_deep_research_inactive` verifies the DR-active indicator is gone. Fail-closed: if DR can't be confirmed inactive (element absent while active, click fails, or still active after), it **aborts the send** rather than confabulating via DR. The genuine `deep_research` mode path returns early — unchanged.

Gates: pytest, all 3 consult-engine validators CLEAN (no-yaml-silent-fallbacks, consultation-v2-contract, platform-independence), new acceptance `tests/test_gemini_deep_research_deselect.py`. Production observation is taeys-hands's (owns the :4 Gemini display): a live `gemini --select model=pro --attach` shows no DR pill + reasons over the attachment.

**Reviewers: read the branch; verify the DR-MODE path is untouched (real deep_research still runs DR) and the non-DR path fails-closed (aborts rather than sending into active DR).**
