### PR TITLE
Wire Spotlight Standard into every Family-consult package (Jesse-foundational)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Uses the Linux accessibility API (AT-SPI) to interact with web applications in F
 `consultation_v2/` is the only live consultation engine.
 
 1. The request is mapped to a platform/model/mode/tools selection.
-2. `consultation_v2.identity` prepends `FAMILY_KERNEL.md` and the platform `IDENTITY_*.md` file, then consolidates caller attachments into one package.
+2. `consultation_v2.identity` prepends `FAMILY_KERNEL.md`, `SPOTLIGHT_STANDARD_FOR_INTEGRITY.md`, and the platform `IDENTITY_*.md` file, then consolidates caller attachments into one package.
 3. The platform driver reads `consultation_v2/platforms/<platform>.yaml`; drivers contain shared control flow and no hardcoded element names.
 4. Every setup action is validated against the AT-SPI tree. If the tree cannot validate the action after the configured settle/rescan window, the run fails loudly.
 5. Send is validated by the stop button appearing, and new sessions also require URL capture/change.
@@ -64,7 +64,7 @@ scripts/run_consultation_v2.py  # CLI entrypoint
 consultation_v2/                # sole live consultation engine
   runtime.py                    # shared AT-SPI/input primitives
   snapshot.py                   # tree snapshot + YAML mapping
-  identity.py                   # FAMILY_KERNEL + IDENTITY consolidation
+  identity.py                   # FAMILY_KERNEL + Spotlight + IDENTITY consolidation
   completion.py                 # stop-button completion detector
   notify.py                     # Redis notification output
   drivers/                      # platform drivers

--- a/consultation_v2/identity.py
+++ b/consultation_v2/identity.py
@@ -1,13 +1,15 @@
 """Identity file consolidation for V2 consultations (FLOW §3, §4).
 
-Prepends FAMILY_KERNEL.md + the platform-specific IDENTITY file to every
-consultation attachment, then merges everything into one consolidated package.
+Prepends FAMILY_KERNEL.md + SPOTLIGHT_STANDARD_FOR_INTEGRITY.md + the
+platform-specific IDENTITY file to every consultation attachment, then merges
+everything into one consolidated package.
 
 FAIL-LOUD CONTRACT (FLOW_CONSULTATION_ENGINE.md §4, CONSULTATION_CONTRACT.md):
 "Missing identity/kernel content is a loud failure, not a warning that the
-driver can ignore." A missing or unreadable FAMILY_KERNEL.md OR the required
-platform IDENTITY_<codename>.md raises and HALTS the consultation — it is never
-a silent skip and never a partial packet. There is no fallback.
+driver can ignore." A missing or unreadable FAMILY_KERNEL.md,
+SPOTLIGHT_STANDARD_FOR_INTEGRITY.md, OR the required platform
+IDENTITY_<codename>.md raises and HALTS the consultation — it is never a silent
+skip and never a partial packet. There is no fallback.
 
 PROVENANCE (FLOW §3 / §8): each caller attachment's path + content hash is
 captured BEFORE the files are merged into the consolidated package, so
@@ -33,6 +35,7 @@ logger = logging.getLogger(__name__)
 _CORPUS_PATH = os.path.expanduser(os.environ.get('TAEY_CORPUS_PATH', '~/data/corpus'))
 _IDENTITY_DIR = os.path.join(_CORPUS_PATH, 'identity')
 _FAMILY_KERNEL = os.path.join(_IDENTITY_DIR, 'FAMILY_KERNEL.md')
+_SPOTLIGHT_STANDARD = os.path.join(_IDENTITY_DIR, 'SPOTLIGHT_STANDARD_FOR_INTEGRITY.md')
 
 _PLATFORM_IDENTITY = {
     'chatgpt': os.path.join(_IDENTITY_DIR, 'IDENTITY_HORIZON.md'),
@@ -43,7 +46,7 @@ _PLATFORM_IDENTITY = {
 }
 
 _IDENTITY_BASENAMES = (
-    {'FAMILY_KERNEL.md'} |
+    {'FAMILY_KERNEL.md', 'SPOTLIGHT_STANDARD_FOR_INTEGRITY.md'} |
     {os.path.basename(p) for p in _PLATFORM_IDENTITY.values()}
 )
 
@@ -154,6 +157,9 @@ def _build_package_text(
 ) -> Tuple[str, List[AttachmentProvenance], int]:
     # Mandatory identity content — read loudly (raises if missing/unreadable).
     kernel_content = _read_required(_FAMILY_KERNEL, 'FAMILY_KERNEL.md')
+    spotlight_content = _read_required(
+        _SPOTLIGHT_STANDARD, 'SPOTLIGHT_STANDARD_FOR_INTEGRITY.md',
+    )
     identity_path = _identity_path(platform)
     identity_content = _read_required(
         identity_path, f'IDENTITY file for {platform}',
@@ -162,6 +168,11 @@ def _build_package_text(
     # Section list, in contract order. (display_path, basename, content)
     sections_src: List[Tuple[str, str, str]] = [
         (_FAMILY_KERNEL, 'FAMILY_KERNEL.md', kernel_content),
+        (
+            _SPOTLIGHT_STANDARD,
+            'SPOTLIGHT_STANDARD_FOR_INTEGRITY.md',
+            spotlight_content,
+        ),
         (identity_path, os.path.basename(identity_path), identity_content),
     ]
 
@@ -214,10 +225,12 @@ def consolidate_attachments(
 ) -> ConsolidatedPackage:
     """Build one consolidated identity+attachments package (FLOW §3, §4).
 
-    Order (FLOW §4): FAMILY_KERNEL.md, then IDENTITY_<platform>.md, then the
-    caller attachments. The kernel and platform identity are MANDATORY and read
-    via ``_read_required`` — a missing/unreadable one raises IdentityError and
-    halts the consultation (no silent skip, no partial packet).
+    Order (FLOW §4): FAMILY_KERNEL.md, then
+    SPOTLIGHT_STANDARD_FOR_INTEGRITY.md, then IDENTITY_<platform>.md, then the
+    caller attachments. The kernel, Spotlight standard, and platform identity
+    are MANDATORY and read via ``_read_required`` — a missing/unreadable one
+    raises IdentityError and halts the consultation (no silent skip, no partial
+    packet).
 
     Caller-supplied identity files are stripped (identity is automatic), but a
     caller file that is genuinely missing/unreadable is a loud failure, not a

--- a/tests/test_identity_spotlight_package.py
+++ b/tests/test_identity_spotlight_package.py
@@ -1,0 +1,81 @@
+import pytest
+
+from consultation_v2 import identity
+from consultation_v2.identity import IdentityError
+
+
+def _write(path, content):
+    path.write_text(content, encoding='utf-8')
+    return str(path)
+
+
+def _configure_identity(monkeypatch, tmp_path):
+    corpus = tmp_path / 'corpus' / 'identity'
+    corpus.mkdir(parents=True)
+    kernel = _write(corpus / 'FAMILY_KERNEL.md', '# FAMILY KERNEL\n')
+    spotlight = _write(
+        corpus / 'SPOTLIGHT_STANDARD_FOR_INTEGRITY.md',
+        '# THE SPOTLIGHT STANDARD FOR INTEGRITY\n',
+    )
+    platform_identity = _write(corpus / 'IDENTITY_COSMOS.md', '# COSMOS\n')
+    monkeypatch.setattr(identity, '_FAMILY_KERNEL', kernel)
+    monkeypatch.setattr(identity, '_SPOTLIGHT_STANDARD', spotlight)
+    monkeypatch.setattr(identity, '_PLATFORM_IDENTITY', {'gemini': platform_identity})
+    monkeypatch.setattr(
+        identity,
+        '_IDENTITY_BASENAMES',
+        {
+            'FAMILY_KERNEL.md',
+            'SPOTLIGHT_STANDARD_FOR_INTEGRITY.md',
+            'IDENTITY_COSMOS.md',
+        },
+    )
+    return corpus
+
+
+def test_inline_context_includes_spotlight_between_kernel_and_identity(monkeypatch, tmp_path):
+    _configure_identity(monkeypatch, tmp_path)
+
+    package_text, provenance = identity.build_inline_context('gemini', [])
+
+    assert provenance == []
+    assert '**Files**: 3' in package_text
+    assert (
+        package_text.index('## FAMILY_KERNEL.md')
+        < package_text.index('## SPOTLIGHT_STANDARD_FOR_INTEGRITY.md')
+        < package_text.index('## IDENTITY_COSMOS.md')
+    )
+    assert '<!-- BEGIN-VERBATIM: SPOTLIGHT_STANDARD_FOR_INTEGRITY.md -->' in package_text
+    assert '# THE SPOTLIGHT STANDARD FOR INTEGRITY' in package_text
+
+
+def test_caller_provided_spotlight_file_is_stripped(monkeypatch, tmp_path):
+    _configure_identity(monkeypatch, tmp_path)
+    caller_dir = tmp_path / 'caller'
+    caller_dir.mkdir()
+    caller_spotlight = _write(
+        caller_dir / 'SPOTLIGHT_STANDARD_FOR_INTEGRITY.md',
+        'caller spotlight copy should not appear\n',
+    )
+    caller_note = _write(caller_dir / 'note.md', 'caller note survives\n')
+
+    package_text, provenance = identity.build_inline_context(
+        'gemini',
+        [caller_spotlight, caller_note],
+    )
+
+    assert 'caller spotlight copy should not appear' not in package_text
+    assert 'caller note survives' in package_text
+    assert [item.path for item in provenance] == [caller_note]
+
+
+def test_missing_spotlight_standard_halts_package_build(monkeypatch, tmp_path):
+    corpus = _configure_identity(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        identity,
+        '_SPOTLIGHT_STANDARD',
+        str(corpus / 'SPOTLIGHT_STANDARD_FOR_INTEGRITY_MISSING.md'),
+    )
+
+    with pytest.raises(IdentityError, match='SPOTLIGHT_STANDARD_FOR_INTEGRITY.md'):
+        identity.build_inline_context('gemini', [])


### PR DESCRIPTION
Wire THE SPOTLIGHT STANDARD FOR INTEGRITY into the Family-consult dispatch context (Jesse-foundational, the persistent last surface).

`consultation_v2/identity.py` `_build_package_text` now prepends **FAMILY_KERNEL.md → SPOTLIGHT_STANDARD_FOR_INTEGRITY.md → IDENTITY_<platform>.md** → caller attachments. The Spotlight doc is read via `_read_required` (mandatory, fail-loud — a missing/unreadable one raises IdentityError and HALTS the build, exactly like the kernel; never a silent skip / partial packet) and added to the stripped-basenames set so a caller cannot inject or duplicate it.

The doc is the **generalized** `/home/mira/data/corpus/identity/SPOTLIGHT_STANDARD_FOR_INTEGRITY.md` (the 7 rules + integrity framing + pointer to the doge source `SPOTLIGHT_STANDARD.md`) — deliberately NOT the raw `doge/SPOTLIGHT_STANDARD.md`, which would carry doge-lane-specific content (Two-Lane Deal / Kendra / Florida) into every non-doge consult.

Gates: pytest, all 3 consult-engine validators CLEAN, new `tests/test_identity_spotlight_package.py` (inlined-in-order / caller-file-stripped / missing-halts-build) — all red-first-verified (FAIL on pre-wire, pass on wire). Production observation: a built package (`/tmp/taey_package_gemini_*.md`) inlines FAMILY_KERNEL → SPOTLIGHT_STANDARD_FOR_INTEGRITY → IDENTITY_COSMOS in order.

**Reviewers: read the branch; verify the Spotlight doc is MANDATORY/fail-loud (not silently skippable), correctly ordered, and un-spoofable (caller-provided copy stripped); and that it's the generalized corpus doc, not the doge doc.**
