### PR TITLE
Harden Spotlight caller-strip test against the production basenames set (PR #15 follow-up)

### DIFF
--- a/tests/test_identity_spotlight_package.py
+++ b/tests/test_identity_spotlight_package.py
@@ -4,12 +4,15 @@ from consultation_v2 import identity
 from consultation_v2.identity import IdentityError
 
 
+SPOTLIGHT_BASENAME = 'SPOTLIGHT_STANDARD_FOR_INTEGRITY.md'
+
+
 def _write(path, content):
     path.write_text(content, encoding='utf-8')
     return str(path)
 
 
-def _configure_identity(monkeypatch, tmp_path):
+def _configure_identity(monkeypatch, tmp_path, *, patch_identity_basenames=True):
     corpus = tmp_path / 'corpus' / 'identity'
     corpus.mkdir(parents=True)
     kernel = _write(corpus / 'FAMILY_KERNEL.md', '# FAMILY KERNEL\n')
@@ -21,15 +24,16 @@ def _configure_identity(monkeypatch, tmp_path):
     monkeypatch.setattr(identity, '_FAMILY_KERNEL', kernel)
     monkeypatch.setattr(identity, '_SPOTLIGHT_STANDARD', spotlight)
     monkeypatch.setattr(identity, '_PLATFORM_IDENTITY', {'gemini': platform_identity})
-    monkeypatch.setattr(
-        identity,
-        '_IDENTITY_BASENAMES',
-        {
-            'FAMILY_KERNEL.md',
-            'SPOTLIGHT_STANDARD_FOR_INTEGRITY.md',
-            'IDENTITY_COSMOS.md',
-        },
-    )
+    if patch_identity_basenames:
+        monkeypatch.setattr(
+            identity,
+            '_IDENTITY_BASENAMES',
+            {
+                'FAMILY_KERNEL.md',
+                SPOTLIGHT_BASENAME,
+                'IDENTITY_COSMOS.md',
+            },
+        )
     return corpus
 
 
@@ -50,11 +54,12 @@ def test_inline_context_includes_spotlight_between_kernel_and_identity(monkeypat
 
 
 def test_caller_provided_spotlight_file_is_stripped(monkeypatch, tmp_path):
-    _configure_identity(monkeypatch, tmp_path)
+    _configure_identity(monkeypatch, tmp_path, patch_identity_basenames=False)
+    assert SPOTLIGHT_BASENAME in identity._IDENTITY_BASENAMES
     caller_dir = tmp_path / 'caller'
     caller_dir.mkdir()
     caller_spotlight = _write(
-        caller_dir / 'SPOTLIGHT_STANDARD_FOR_INTEGRITY.md',
+        caller_dir / SPOTLIGHT_BASENAME,
         'caller spotlight copy should not appear\n',
     )
     caller_note = _write(caller_dir / 'note.md', 'caller note survives\n')


### PR DESCRIPTION
Test-hardening (gatekeeper's non-blocking coverage note on PR #15): the original caller-strip test injected its OWN `_IDENTITY_BASENAMES`, so a future revert removing `SPOTLIGHT_STANDARD_FOR_INTEGRITY.md` from the PRODUCTION set wouldn't be caught by that test alone.

This adds an assertion against the REAL production `identity._IDENTITY_BASENAMES` (`patch_identity_basenames=False` → `assert SPOTLIGHT_BASENAME in identity._IDENTITY_BASENAMES`) and exercises the caller-strip through the production set. So a future revert that drops the Spotlight basename from the production set now fails the suite. Test-only; the Spotlight wire behavior is unchanged.

Gates: pytest 15/15, all 3 consult-engine validators CLEAN. Production check: a built package (`/tmp/taey_package_gemini_*.md`) with a malicious caller Spotlight attachment → `basename_present=True, spotlight_sections=1, caller_provenance=0` (stripped via the production basenames).

**Reviewers: confirm the new assertion targets the PRODUCTION `_IDENTITY_BASENAMES` (not an injected copy) so it catches a future revert; test-only, no behavior change.**
