### PR TITLE
Fix Grok exact Submit send contract

### DIFF
--- a/consultation_v2/platforms/grok/driver.py
+++ b/consultation_v2/platforms/grok/driver.py
@@ -1782,7 +1782,7 @@ class _GrokInlineBase:
     # checkpoint the load-bearing milestones into it, and at the send seam we
     # READ it first. A prior submitted URL resumes directly. A prior
     # setup_complete is quarantined as possibly-landed: verify/resume a live URL
-    # if one exists, otherwise fail closed instead of replaying Enter.
+    # if one exists, otherwise fail closed instead of replaying the send action.
     #
     # This lives in the base driver, called from ONE seam in each platform
     # driver's run() (``guarded_send`` replaces the direct ``send_prompt`` call),
@@ -2000,7 +2000,7 @@ class _GrokInlineBase:
             'duplicate_send_quarantine',
             True,
             f'{self.platform} prior setup_complete may have landed a send; '
-            f'resuming live answer thread instead of replaying Enter',
+            f'resuming live answer thread instead of replaying the send action',
             prior_status=prior.get('status'),
             live_url=live_url,
             duplicate_send_risk=True,
@@ -3482,7 +3482,7 @@ class GrokConsultationDriver(_GrokInlineBase):
         return True
 
     # ------------------------------------------------------------------
-    # Step 5 - send (focused composer + Return; hard answer-thread URL gate)
+    # Step 5 - send (exact YAML action; hard Stop + answer-thread URL gate)
     # ------------------------------------------------------------------
     def send_prompt(self, request: ConsultationRequest, result: ConsultationResult) -> bool:
         before = self.runtime.current_url() or result.session_url_before
@@ -3496,12 +3496,58 @@ class GrokConsultationDriver(_GrokInlineBase):
         copy_key = self.cfg['workflow']['extract']['primary_key']
         pre_send_copy_baseline = self._copy_button_baseline(copy_key)
         self._pre_send_copy_button_baseline = pre_send_copy_baseline
-        if not self.runtime.press('Return'):
-            result.add_step('send', False, 'Grok Return keypress failed')
+
+        # Grok's composer is multiline, so Return edits the prompt. The YAML
+        # exact-match element is the single authoritative submit action.
+        send_key = self.cfg['workflow']['send']['send_key']
+        send_ready_snap, send_el = self.wait_for_key(
+            send_key,
+            timeout=10.0,
+            interval=0.4,
+            scope='document',
+        )
+        if not send_el:
+            result.add_step(
+                'send_action',
+                False,
+                'Grok configured send element not found before the single action',
+                send_key=send_key,
+                click_strategy='atspi_only',
+                snapshot=send_ready_snap.serializable(),
+            )
             return False
 
-        send_snap = self.wait_for_validation('send_fired', timeout=12.0, interval=0.5)
-        stop_seen = self.validation_passes(send_snap, 'send_fired')
+        click_returned = self.runtime.click(send_el, strategy='atspi_only')
+        immediate_snap = self.runtime.snapshot()
+        immediate_url = self.runtime.current_url() or before
+        immediate_stop_seen = self.validation_passes(immediate_snap, 'send_fired')
+        result.add_step(
+            'send_action',
+            bool(click_returned),
+            (
+                'Grok exact send element clicked once; awaiting landed-send gates'
+                if click_returned else
+                'Grok exact send element click failed'
+            ),
+            send_key=send_key,
+            click_strategy='atspi_only',
+            click_returned=bool(click_returned),
+            target=send_el.serializable(),
+            url_before=before,
+            url_immediate_after=immediate_url,
+            stop_seen_immediately=bool(immediate_stop_seen),
+            snapshot=immediate_snap.serializable(),
+        )
+        if not click_returned:
+            return False
+
+        send_snap = immediate_snap
+        if not immediate_stop_seen:
+            send_snap = self.wait_for_validation('send_fired', timeout=12.0, interval=0.5)
+        stop_seen = bool(
+            immediate_stop_seen
+            or self.validation_passes(send_snap, 'send_fired')
+        )
         # Carry the send-phase stop observation into the shared completion
         # detector (a fast reply can clear the stop button before monitor runs).
         self._send_stop_seen = bool(stop_seen)


### PR DESCRIPTION
## Summary

- Restore Grok send dispatch to the YAML-defined exact send element with one AT-SPI action.
- Record immediate post-action evidence: configured key, exact target, action return, URL, Stop observation, and fresh tree snapshot.
- Preserve the existing Stop-button and answer-thread URL hard gates, including the fast-response Stop carry-forward.

## Root cause

The live Grok scan established that its composer is multiline and Return edits the prompt rather than submitting it. An earlier extraction of the platform driver reintroduced a hard-coded Return path even though the package-owned YAML still declared the exact Submit control.

## Impact

Grok consultations now follow the package-owned production contract at the irreversible send seam. The action remains single-shot with no retry or fallback.

## Static validation

- Python bytecode compilation passed.
- Platform-independence lint: 0 findings.
- Consultation contract lint: 0 findings.
- Exact-match lint: 0 loose matchers.
- YAML silent-fallback integrity gate: 0 findings.
- GitNexus pre-edit impact: LOW.
- GitNexus compare scope: one changed file, five Grok send flows, MEDIUM aggregate scope.
- GitHub YAML Integrity Gate: success.
- GitGuardian Security Checks: success.

## Production observation

A real end-to-end Grok Fast verification ran through the production wrapper on display :5 at 2026-07-30T15:13:18Z. It used fresh request ID 9b8a22942f63190d381232141be4bef1; the poisoned request 3af79818f678756d839fd89e7a1ebcad was not replayed.

Observed result:

- exact action target: key send_button, name Submit, role push button
- click strategy: atspi_only
- click returned true
- immediate fresh snapshot contained one stop_button
- URL changed from grok.com root to answer thread 5219cd05-421e-491e-b53b-9a3c9aaccdf4
- send hard gate: success with Stop seen, URL changed, answer thread true
- monitor: success
- extraction: success, 3,100 characters
- requester notification: queued successfully
- Grok bounded verification verdict: PASS
- result artifact SHA-256: 2e0f4d3ca7ce491a30e6bb486e5c39c84bbf73701ad0f26d2ece912389a0315e

Closes task-9f2f222c.