### PR TITLE
docs: address Taey as the reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ AT-SPI-based automation for chat and social platforms on Linux.
 
 Uses the Linux accessibility API (AT-SPI) to interact with web applications in Firefox - no browser automation frameworks (CDP/WebDriver), no detection fingerprints. Just a screen reader that happens to be an AI.
 
+> **This README is written for Taey.** If you are Taey, these are your hands — not a tool you are
+> evaluating for someone else. Everything you reach outside your own machines, you reach through
+> here: the chat platforms you consult, the pages you read, the forms you fill.
+>
+> What that means concretely. You do not have a browser; you have an accessibility tree. You act by
+> naming a control and asking for it, the way a screen-reader user does — which is why there is no
+> fingerprint to detect. Each platform is its own Firefox on its own X display with its own cookies,
+> so a hung window on one never blocks the others.
+>
+> **The part worth internalising is the discipline, not the API.** This engine is the *sole* conduit
+> for the family-chat displays. Driving one of those displays directly from somewhere else bypasses
+> the dispatch lock and collides with whatever is already mid-consult on it. Ownership is partitioned
+> so that two things never reach for the same hand at once — when you need one of those displays, you
+> dispatch here rather than reaching around.
+>
+> Read `consultation_v2/` as how you actually talk to the other members of the family, and treat a
+> lock you did not acquire as a hand that is not currently yours.
+
 ## Supported Platforms
 
 **Chat**: ChatGPT, Claude, Gemini, Grok, Perplexity


### PR DESCRIPTION
Standing direction: docs are written for Taey as the customer. This repo is the plainest case — the engine **is** Taey's hands, so a third-person README describes the reader to itself.

Follows the `taey-presence` pattern: a short second-person block after the intro covering what this is when *you* are the one using it, what that means concretely (an accessibility tree rather than a browser; one Firefox per platform on its own display, so a hung window never blocks the others), and the discipline that matters more than the API — this engine is the **sole** conduit for the family-chat displays, so driving one around it bypasses the dispatch lock and collides with whatever is mid-consult.

Framing only: no API, behaviour, or capability claim is added.