### PR TITLE
[codex] strengthen stay-clean artifact detection

### DIFF
--- a/.github/workflows/stay-clean.yml
+++ b/.github/workflows/stay-clean.yml
@@ -48,34 +48,55 @@ jobs:
             return 1
           }
 
-          fails=0
+          is_data_shaped_path() {
+            local path_lc="${1,,}"
+            case "$path_lc" in
+              *.gz|*.zst|*.xz)
+                path_lc="${path_lc%.*}"
+                ;;
+            esac
+            case "$path_lc" in
+              *.jsonl|*.parquet|*.csv|*.tsv|*.feather|*.arrow|*.npz|*.npy|*.pt|*.pth|*.safetensors|*.db|*.sqlite)
+                return 0
+                ;;
+            esac
+            return 1
+          }
 
-          while IFS= read -r path; do
+          fails=0
+          tmp_files="$(mktemp)"
+          cleanup() { rm -f "$tmp_files"; }
+          trap cleanup EXIT
+
+          if ! git ls-files -z > "$tmp_files"; then
+            echo "::error::failed to enumerate tracked files with git ls-files"
+            exit 1
+          fi
+
+          while IFS= read -r -d '' path; do
             [ -n "$path" ] || continue
-            if ! listed_exact "$path" "$ROOT_MD_ALLOWLIST"; then
+            path_lc="${path,,}"
+
+            if [[ "$path" != */* && "$path_lc" == *.md ]] && ! listed_exact "$path" "$ROOT_MD_ALLOWLIST"; then
               echo "::error file=$path::root-level Markdown is not allowlisted; put working docs under docs/ or the tracker"
               fails=$((fails + 1))
             fi
-          done < <(git ls-files '*.md' | awk 'index($0, "/") == 0' | sort)
 
-          while IFS= read -r path; do
-            [ -n "$path" ] || continue
-            if ! listed_exact "$path" "$DATA_OR_LARGE_ALLOWLIST"; then
-              echo "::error file=$path::data-shaped files (*.jsonl/*.parquet) must be deliberately allowlisted"
+            if is_data_shaped_path "$path" && ! listed_exact "$path" "$DATA_OR_LARGE_ALLOWLIST"; then
+              echo "::error file=$path::data-shaped files must be deliberately allowlisted"
               fails=$((fails + 1))
             fi
-          done < <(git ls-files '*.jsonl' '*.parquet' | sort)
 
-          while IFS= read -r -d '' path; do
-            size="$(wc -c < "$path")"
-            if [ "$size" -le "$ONE_MIB" ]; then
-              continue
+            if ! size="$(wc -c < "$path")"; then
+              echo "::error file=$path::failed to read tracked file for size check"
+              exit 1
             fi
-            if ! listed_exact "$path" "$DATA_OR_LARGE_ALLOWLIST"; then
+            # The size check is the backstop for data formats we do not know by extension yet.
+            if [ "$size" -gt "$ONE_MIB" ] && ! listed_exact "$path" "$DATA_OR_LARGE_ALLOWLIST"; then
               echo "::error file=$path::file is ${size} bytes (>1 MiB) and is not allowlisted"
               fails=$((fails + 1))
             fi
-          done < <(git ls-files -z)
+          done < "$tmp_files"
 
           if [ "$fails" -ne 0 ]; then
             echo "stay-clean failed: $fails violation(s)"


### PR DESCRIPTION
## What changed

Strengthens `stay-clean` after audit feedback: broader case-insensitive data extension detection, compressed data suffix handling, and explicit enumeration-failure propagation.

## Checks

- `git diff --check`
- parsed and ran `.github/workflows/stay-clean.yml` locally
- alternate-index probes rejected `UPPER.JSONL` and `table.CSV.GZ`
- failing `git ls-files` shim exited nonzero with an explicit enumeration error
- `npx gitnexus detect-changes --scope staged --repo taeys-hands`
