### PR TITLE
Implement approval-gated supervised UI seat

### DIFF
--- a/consultation_v2/__init__.py
+++ b/consultation_v2/__init__.py
@@ -5,9 +5,8 @@ Shared code in this package is limited to AT-SPI/YAML plumbing and result
 data structures.
 """
 
-from . import primitives
-from .orchestrator import run_consultation
-from .types import Choice, ConsultationRequest, ConsultationResult
+from importlib import import_module
+from typing import Any
 
 __all__ = [
     'Choice',
@@ -16,3 +15,22 @@ __all__ = [
     'primitives',
     'run_consultation',
 ]
+
+_EXPORTS = {
+    'Choice': ('.types', 'Choice'),
+    'ConsultationRequest': ('.types', 'ConsultationRequest'),
+    'ConsultationResult': ('.types', 'ConsultationResult'),
+    'primitives': ('.primitives', None),
+    'run_consultation': ('.orchestrator', 'run_consultation'),
+}
+
+
+def __getattr__(name: str) -> Any:
+    try:
+        module_name, attribute_name = _EXPORTS[name]
+    except KeyError as exc:
+        raise AttributeError(f'module {__name__!r} has no attribute {name!r}') from exc
+    module = import_module(module_name, __name__)
+    value = module if attribute_name is None else getattr(module, attribute_name)
+    globals()[name] = value
+    return value

--- a/consultation_v2/platforms/chatgpt/supervised_ui.yaml
+++ b/consultation_v2/platforms/chatgpt/supervised_ui.yaml
@@ -1,0 +1,26 @@
+schema: supervised_ui_policy_v1
+controls:
+  input_ask_anything:
+    control_id: prompt_composer_alternate
+    label: Alternate prompt composer
+    role: entry
+    operations:
+      - focus
+    effect_class: local
+    postconditions:
+      focus:
+        states_include:
+          - focused
+        states_exclude: []
+  input_chat_with_chatgpt:
+    control_id: prompt_composer_primary
+    label: Primary prompt composer
+    role: entry
+    operations:
+      - focus
+    effect_class: local
+    postconditions:
+      focus:
+        states_include:
+          - focused
+        states_exclude: []

--- a/consultation_v2/platforms/claude/supervised_ui.yaml
+++ b/consultation_v2/platforms/claude/supervised_ui.yaml
@@ -1,0 +1,14 @@
+schema: supervised_ui_policy_v1
+controls:
+  input:
+    control_id: prompt_composer
+    label: Prompt composer
+    role: entry
+    operations:
+      - focus
+    effect_class: local
+    postconditions:
+      focus:
+        states_include:
+          - focused
+        states_exclude: []

--- a/consultation_v2/platforms/gemini/supervised_ui.yaml
+++ b/consultation_v2/platforms/gemini/supervised_ui.yaml
@@ -1,0 +1,14 @@
+schema: supervised_ui_policy_v1
+controls:
+  input:
+    control_id: prompt_composer
+    label: Prompt composer
+    role: entry
+    operations:
+      - focus
+    effect_class: local
+    postconditions:
+      focus:
+        states_include:
+          - focused
+        states_exclude: []

--- a/consultation_v2/platforms/grok/supervised_ui.yaml
+++ b/consultation_v2/platforms/grok/supervised_ui.yaml
@@ -1,0 +1,14 @@
+schema: supervised_ui_policy_v1
+controls:
+  input:
+    control_id: prompt_composer
+    label: Prompt composer
+    role: entry
+    operations:
+      - focus
+    effect_class: local
+    postconditions:
+      focus:
+        states_include:
+          - focused
+        states_exclude: []

--- a/consultation_v2/platforms/perplexity/supervised_ui.yaml
+++ b/consultation_v2/platforms/perplexity/supervised_ui.yaml
@@ -1,0 +1,26 @@
+schema: supervised_ui_policy_v1
+controls:
+  input:
+    control_id: prompt_composer_primary
+    label: Primary prompt composer
+    role: entry
+    operations:
+      - focus
+    effect_class: local
+    postconditions:
+      focus:
+        states_include:
+          - focused
+        states_exclude: []
+  input_message:
+    control_id: prompt_composer_alternate
+    label: Alternate prompt composer
+    role: entry
+    operations:
+      - focus
+    effect_class: local
+    postconditions:
+      focus:
+        states_include:
+          - focused
+        states_exclude: []

--- a/consultation_v2/supervised_ui_contract.py
+++ b/consultation_v2/supervised_ui_contract.py
@@ -1,0 +1,540 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+import hashlib
+import hmac
+import json
+from pathlib import Path
+import re
+from typing import Any, Mapping
+
+import yaml
+
+from .types import ElementRef, Snapshot
+
+
+CONTRACT_VERSION = 'supervised_ui_v1'
+POLICY_SCHEMA = 'supervised_ui_policy_v1'
+PROJECTION_SCHEMA = 'supervised_ui_projection_v1'
+TRAINING_PROTOCOL_COMMIT = '58b108042e66fa508765a6277c033cc5a8f86abd'
+
+_PLATFORM_RE = re.compile(r'^[a-z][a-z0-9_]{0,31}$')
+_CONTROL_ID_RE = re.compile(r'^[a-z][a-z0-9_]{0,63}$')
+_REF_RE = re.compile(r'^r_[0-9a-f]{32}$')
+_SHA256_RE = re.compile(r'^[0-9a-f]{64}$')
+_UUID_RE = re.compile(
+    r'^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+)
+_PUBLIC_ROLES = frozenset({
+    'check box',
+    'combo box',
+    'entry',
+    'menu item',
+    'option',
+    'page tab',
+    'push button',
+    'radio button',
+    'radio menu item',
+    'toggle button',
+})
+_PUBLIC_STATES = frozenset({
+    'active',
+    'checked',
+    'editable',
+    'enabled',
+    'expandable',
+    'expanded',
+    'focusable',
+    'focused',
+    'indeterminate',
+    'modal',
+    'multi line',
+    'pressed',
+    'required',
+    'selectable',
+    'selected',
+    'showing',
+    'single line',
+    'visible',
+})
+_ACTION_OPERATIONS = frozenset({'activate', 'focus'})
+_READ_OPERATIONS = frozenset({'observe', 'verify'})
+_PUBLIC_TEXT_FORBIDDEN = re.compile(
+    r'(?:https?://|www\.|[/\\]|@|token|secret|password|credential|api[_ -]?key|'
+    r'claude|chatgpt|openai|gemini|google|grok|perplexity|nvidia|reddit)',
+    re.IGNORECASE,
+)
+
+
+class SupervisedUiContractError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyControl:
+    mapping_key: str
+    control_id: str
+    label: str
+    role: str
+    operations: tuple[str, ...]
+    effect_class: str
+    postconditions: Mapping[str, Mapping[str, tuple[str, ...]]]
+
+
+@dataclass(frozen=True, slots=True)
+class SupervisedPolicy:
+    platform: str
+    controls: Mapping[str, PolicyControl]
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectedSnapshot:
+    public: Mapping[str, Any]
+    bindings: Mapping[str, ElementRef]
+    omissions: tuple[Mapping[str, Any], ...]
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(',', ':'),
+    ).encode('utf-8')
+
+
+def sha256_hex(raw_bytes: bytes) -> str:
+    return hashlib.sha256(raw_bytes).hexdigest()
+
+
+def _policy_path(platform: str) -> Path:
+    if not isinstance(platform, str) or not _PLATFORM_RE.fullmatch(platform):
+        raise SupervisedUiContractError('invalid supervised UI platform identifier')
+    return Path(__file__).resolve().parent / 'platforms' / platform / 'supervised_ui.yaml'
+
+
+def _plain_mapping(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or any(not isinstance(key, str) for key in value):
+        raise SupervisedUiContractError(f'{context} must be a string-keyed mapping')
+    return dict(value)
+
+
+def _require_exact_keys(
+    value: Mapping[str, Any],
+    *,
+    required: frozenset[str],
+    context: str,
+) -> None:
+    keys = frozenset(value)
+    if keys != required:
+        missing = sorted(required - keys)
+        unknown = sorted(keys - required)
+        raise SupervisedUiContractError(
+            f'{context} keys mismatch: missing={missing}, unknown={unknown}'
+        )
+
+
+def _public_label(value: Any, context: str) -> str:
+    if not isinstance(value, str):
+        raise SupervisedUiContractError(f'{context} must be a string')
+    normalized = ' '.join(value.split())
+    if not normalized or len(normalized) > 80:
+        raise SupervisedUiContractError(f'{context} must contain 1-80 visible characters')
+    if not normalized.isascii() or _PUBLIC_TEXT_FORBIDDEN.search(normalized):
+        raise SupervisedUiContractError(f'{context} is not public-safe')
+    return normalized
+
+
+def _normalized_state(value: Any, context: str) -> str:
+    if not isinstance(value, str):
+        raise SupervisedUiContractError(f'{context} must be a string')
+    normalized = ' '.join(value.strip().lower().replace('_', ' ').split())
+    if normalized not in _PUBLIC_STATES:
+        raise SupervisedUiContractError(f'{context} contains disallowed state {value!r}')
+    return normalized
+
+
+@lru_cache(maxsize=None)
+def load_supervised_policy(platform: str) -> SupervisedPolicy:
+    path = _policy_path(platform)
+    if not path.is_file() or path.is_symlink():
+        raise FileNotFoundError(path)
+    raw = yaml.safe_load(path.read_text(encoding='utf-8'))
+    document = _plain_mapping(raw, path.name)
+    _require_exact_keys(
+        document,
+        required=frozenset({'schema', 'controls'}),
+        context=path.name,
+    )
+    if document['schema'] != POLICY_SCHEMA:
+        raise SupervisedUiContractError(f'{path.name} has unsupported schema')
+    raw_controls = _plain_mapping(document['controls'], f'{path.name}.controls')
+    if not raw_controls:
+        raise SupervisedUiContractError(f'{path.name}.controls must not be empty')
+
+    controls: dict[str, PolicyControl] = {}
+    public_ids: set[str] = set()
+    for mapping_key, raw_control in sorted(raw_controls.items()):
+        if not _CONTROL_ID_RE.fullmatch(mapping_key):
+            raise SupervisedUiContractError(f'invalid mapping key {mapping_key!r}')
+        control = _plain_mapping(raw_control, f'controls.{mapping_key}')
+        _require_exact_keys(
+            control,
+            required=frozenset({
+                'control_id',
+                'effect_class',
+                'label',
+                'operations',
+                'postconditions',
+                'role',
+            }),
+            context=f'controls.{mapping_key}',
+        )
+        control_id = control['control_id']
+        if not isinstance(control_id, str) or not _CONTROL_ID_RE.fullmatch(control_id):
+            raise SupervisedUiContractError(f'controls.{mapping_key}.control_id is invalid')
+        if _PUBLIC_TEXT_FORBIDDEN.search(control_id):
+            raise SupervisedUiContractError(f'controls.{mapping_key}.control_id is not public-safe')
+        if control_id in public_ids:
+            raise SupervisedUiContractError(f'duplicate public control_id {control_id!r}')
+        public_ids.add(control_id)
+        label = _public_label(control['label'], f'controls.{mapping_key}.label')
+        role = control['role']
+        if role not in _PUBLIC_ROLES:
+            raise SupervisedUiContractError(f'controls.{mapping_key}.role is not allowlisted')
+        operations_value = control['operations']
+        if not isinstance(operations_value, list) or not operations_value:
+            raise SupervisedUiContractError(f'controls.{mapping_key}.operations must be a list')
+        if any(operation not in _ACTION_OPERATIONS for operation in operations_value):
+            raise SupervisedUiContractError(f'controls.{mapping_key}.operations is not P0-safe')
+        operations = tuple(sorted(set(operations_value)))
+        if len(operations) != len(operations_value):
+            raise SupervisedUiContractError(f'controls.{mapping_key}.operations contains duplicates')
+        if control['effect_class'] != 'local':
+            raise SupervisedUiContractError(f'controls.{mapping_key}.effect_class must be local')
+        raw_postconditions = _plain_mapping(
+            control['postconditions'],
+            f'controls.{mapping_key}.postconditions',
+        )
+        if frozenset(raw_postconditions) != frozenset(operations):
+            raise SupervisedUiContractError(
+                f'controls.{mapping_key}.postconditions must cover exactly its operations'
+            )
+        postconditions: dict[str, Mapping[str, tuple[str, ...]]] = {}
+        for operation in operations:
+            postcondition = _plain_mapping(
+                raw_postconditions[operation],
+                f'controls.{mapping_key}.postconditions.{operation}',
+            )
+            _require_exact_keys(
+                postcondition,
+                required=frozenset({'states_include', 'states_exclude'}),
+                context=f'controls.{mapping_key}.postconditions.{operation}',
+            )
+            normalized: dict[str, tuple[str, ...]] = {}
+            for condition_key in ('states_include', 'states_exclude'):
+                values = postcondition[condition_key]
+                if not isinstance(values, list):
+                    raise SupervisedUiContractError(
+                        f'controls.{mapping_key}.postconditions.{operation}.{condition_key} '
+                        'must be a list'
+                    )
+                states = tuple(sorted({
+                    _normalized_state(
+                        item,
+                        f'controls.{mapping_key}.postconditions.{operation}.{condition_key}',
+                    )
+                    for item in values
+                }))
+                if len(states) != len(values):
+                    raise SupervisedUiContractError(
+                        f'controls.{mapping_key}.postconditions.{operation}.{condition_key} '
+                        'contains duplicates'
+                    )
+                normalized[condition_key] = states
+            if not normalized['states_include'] and not normalized['states_exclude']:
+                raise SupervisedUiContractError(
+                    f'controls.{mapping_key}.postconditions.{operation} must assert state'
+                )
+            postconditions[operation] = normalized
+        controls[mapping_key] = PolicyControl(
+            mapping_key=mapping_key,
+            control_id=control_id,
+            label=label,
+            role=role,
+            operations=operations,
+            effect_class='local',
+            postconditions=postconditions,
+        )
+    return SupervisedPolicy(platform=platform, controls=controls)
+
+
+def clear_supervised_policy_cache() -> None:
+    load_supervised_policy.cache_clear()
+
+
+def _lease_secret(value: bytes | bytearray) -> bytes:
+    if not isinstance(value, (bytes, bytearray)) or len(value) < 32:
+        raise SupervisedUiContractError('lease secret must contain at least 32 bytes')
+    return bytes(value)
+
+
+def _public_states(states: list[str]) -> list[str]:
+    public: set[str] = set()
+    for value in states:
+        if not isinstance(value, str):
+            continue
+        normalized = ' '.join(value.strip().lower().replace('_', ' ').split())
+        if normalized in _PUBLIC_STATES:
+            public.add(normalized)
+    return sorted(public)
+
+
+def project_snapshot(snapshot: Snapshot, lease_secret: bytes) -> ProjectedSnapshot:
+    secret = _lease_secret(lease_secret)
+    policy = load_supervised_policy(snapshot.platform)
+    public_elements: list[dict[str, Any]] = []
+    bindings: dict[str, ElementRef] = {}
+    omissions: list[Mapping[str, Any]] = []
+    for mapping_key, control in sorted(policy.controls.items()):
+        matches = list((snapshot.mapped or {}).get(mapping_key) or ())
+        if len(matches) != 1:
+            if matches:
+                omissions.append({
+                    'control_id': control.control_id,
+                    'reason': 'mapping_collision',
+                    'match_count': len(matches),
+                })
+            continue
+        element = matches[0]
+        runtime_role = ' '.join(str(element.role).strip().lower().split())
+        if runtime_role != control.role:
+            omissions.append({
+                'control_id': control.control_id,
+                'reason': 'role_mismatch',
+                'match_count': 1,
+            })
+            continue
+        digest = hmac.new(
+            secret,
+            b'supervised-ui-ref-v1\x00' + mapping_key.encode('utf-8'),
+            hashlib.sha256,
+        ).hexdigest()[:32]
+        ref = f'r_{digest}'
+        if ref in bindings:
+            raise SupervisedUiContractError('opaque ref collision')
+        bindings[ref] = element
+        public_elements.append({
+            'control_id': control.control_id,
+            'effect_class': control.effect_class,
+            'label': control.label,
+            'operations': list(control.operations),
+            'ref': ref,
+            'role': control.role,
+            'states': _public_states(element.states),
+        })
+    public_elements.sort(key=lambda item: (item['control_id'], item['ref']))
+    public = {
+        'schema': PROJECTION_SCHEMA,
+        'elements': public_elements,
+    }
+    return ProjectedSnapshot(
+        public=public,
+        bindings=bindings,
+        omissions=tuple(omissions),
+    )
+
+
+def snapshot_revision(
+    projection: ProjectedSnapshot | Mapping[str, Any],
+    lease_secret: bytes,
+) -> str:
+    secret = _lease_secret(lease_secret)
+    public = projection.public if isinstance(projection, ProjectedSnapshot) else projection
+    digest = hmac.new(
+        secret,
+        b'supervised-ui-revision-v1\x00' + canonical_json_bytes(public),
+        hashlib.sha256,
+    ).hexdigest()
+    return f'v1_{digest}'
+
+
+def _read_parameters(operation: str) -> dict[str, Any]:
+    return {
+        'type': 'object',
+        'additionalProperties': False,
+        'properties': {'op': {'type': 'string', 'const': operation}},
+        'required': ['op'],
+    }
+
+
+def build_live_ui_action_schema(
+    state: str,
+    projection: ProjectedSnapshot | Mapping[str, Any] | None = None,
+    revision: str | None = None,
+) -> dict[str, Any]:
+    if state == 'needs_observe':
+        parameters = _read_parameters('observe')
+    elif state == 'needs_verify':
+        parameters = _read_parameters('verify')
+    elif state == 'action_ready':
+        if projection is None or not isinstance(revision, str) or not revision.startswith('v1_'):
+            raise SupervisedUiContractError('action_ready schema requires projection and revision')
+        public = projection.public if isinstance(projection, ProjectedSnapshot) else projection
+        elements = public.get('elements') if isinstance(public, Mapping) else None
+        if not isinstance(elements, list):
+            raise SupervisedUiContractError('invalid public projection')
+        alternatives: list[dict[str, Any]] = []
+        for element in elements:
+            if not isinstance(element, Mapping):
+                raise SupervisedUiContractError('invalid projected element')
+            ref = element.get('ref')
+            operations = element.get('operations')
+            if not isinstance(ref, str) or not _REF_RE.fullmatch(ref):
+                raise SupervisedUiContractError('invalid projected ref')
+            if not isinstance(operations, list):
+                raise SupervisedUiContractError('invalid projected operations')
+            for operation in operations:
+                if operation not in _ACTION_OPERATIONS:
+                    raise SupervisedUiContractError('invalid projected operation')
+                alternatives.append({
+                    'type': 'object',
+                    'additionalProperties': False,
+                    'properties': {
+                        'op': {'type': 'string', 'const': operation},
+                        'ref': {'type': 'string', 'const': ref},
+                        'revision': {'type': 'string', 'const': revision},
+                    },
+                    'required': ['op', 'ref', 'revision'],
+                })
+        if not alternatives:
+            raise SupervisedUiContractError('projection exposes no permitted local action')
+        parameters = {'type': 'object', 'oneOf': alternatives}
+    else:
+        raise SupervisedUiContractError(f'state {state!r} has no live tool schema')
+    return {
+        'type': 'function',
+        'function': {
+            'name': 'ui_action',
+            'description': 'Propose exactly one operation permitted by the current public UI state.',
+            'strict': True,
+            'parameters': parameters,
+        },
+    }
+
+
+def _parse_exact_call(raw_bytes: bytes) -> dict[str, Any]:
+    if not isinstance(raw_bytes, bytes) or not raw_bytes:
+        raise SupervisedUiContractError('proposal must be nonempty exact bytes')
+
+    def reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise SupervisedUiContractError(f'duplicate proposal key {key!r}')
+            result[key] = value
+        return result
+
+    try:
+        text = raw_bytes.decode('utf-8')
+        value = json.loads(
+            text,
+            object_pairs_hook=reject_duplicate_pairs,
+            parse_constant=lambda _value: (_ for _ in ()).throw(
+                SupervisedUiContractError('proposal contains a non-JSON constant')
+            ),
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SupervisedUiContractError('proposal is not strict UTF-8 JSON') from exc
+    return _plain_mapping(value, 'proposal')
+
+
+def _opaque_uuid(value: Any, context: str) -> str:
+    if not isinstance(value, str) or not _UUID_RE.fullmatch(value):
+        raise SupervisedUiContractError(f'{context} must be a lowercase UUID')
+    return value
+
+
+def validate_approved_call(
+    call: bytes,
+    approval: Mapping[str, Any],
+    projection: ProjectedSnapshot | None,
+) -> dict[str, Any]:
+    proposal = _parse_exact_call(call)
+    approval_map = _plain_mapping(approval, 'approval')
+    required_approval = frozenset({
+        'actor_id',
+        'approval_id',
+        'capability_sha256',
+        'effect_class',
+        'execution_id',
+        'expires_at',
+        'hands_incarnation_id',
+        'observation_id',
+        'operation',
+        'presence_incarnation_id',
+        'proposal_id',
+        'proposal_sha256',
+        'ref',
+        'revision',
+        'turn_id',
+    })
+    _require_exact_keys(approval_map, required=required_approval, context='approval')
+    for key in (
+        'actor_id',
+        'approval_id',
+        'execution_id',
+        'hands_incarnation_id',
+        'presence_incarnation_id',
+        'proposal_id',
+        'turn_id',
+    ):
+        _opaque_uuid(approval_map[key], f'approval.{key}')
+    observation_id = approval_map['observation_id']
+    if observation_id is not None:
+        _opaque_uuid(observation_id, 'approval.observation_id')
+    for key in ('capability_sha256', 'proposal_sha256'):
+        if not isinstance(approval_map[key], str) or not _SHA256_RE.fullmatch(approval_map[key]):
+            raise SupervisedUiContractError(f'approval.{key} must be a SHA-256 digest')
+    if not hmac.compare_digest(approval_map['proposal_sha256'], sha256_hex(call)):
+        raise SupervisedUiContractError('approval proposal digest mismatch')
+    operation = proposal.get('op')
+    if operation not in _READ_OPERATIONS | _ACTION_OPERATIONS:
+        raise SupervisedUiContractError('proposal operation is not allowed')
+    if approval_map['operation'] != operation:
+        raise SupervisedUiContractError('approval operation mismatch')
+    if operation in _READ_OPERATIONS:
+        _require_exact_keys(proposal, required=frozenset({'op'}), context='proposal')
+        if any(approval_map[key] is not None for key in ('ref', 'revision', 'observation_id')):
+            raise SupervisedUiContractError('read approval must not bind a prior UI target')
+        if approval_map['effect_class'] != 'read_only':
+            raise SupervisedUiContractError('read approval effect must be read_only')
+        return proposal
+    _require_exact_keys(
+        proposal,
+        required=frozenset({'op', 'ref', 'revision'}),
+        context='proposal',
+    )
+    if projection is None:
+        raise SupervisedUiContractError('action proposal requires a current projection')
+    ref = proposal['ref']
+    revision = proposal['revision']
+    if not isinstance(ref, str) or not _REF_RE.fullmatch(ref):
+        raise SupervisedUiContractError('proposal ref is invalid')
+    if not isinstance(revision, str) or not revision.startswith('v1_'):
+        raise SupervisedUiContractError('proposal revision is invalid')
+    if approval_map['ref'] != ref or approval_map['revision'] != revision:
+        raise SupervisedUiContractError('approval target mismatch')
+    element = next(
+        (item for item in projection.public['elements'] if item['ref'] == ref),
+        None,
+    )
+    if element is None or operation not in element['operations']:
+        raise SupervisedUiContractError('proposal is outside the live projection')
+    if approval_map['effect_class'] != element['effect_class']:
+        raise SupervisedUiContractError('approval effect mismatch')
+    if observation_id is None:
+        raise SupervisedUiContractError('action approval must bind its observation')
+    return proposal

--- a/consultation_v2/supervised_ui_receipts.py
+++ b/consultation_v2/supervised_ui_receipts.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import time
+from typing import Any, Mapping
+import uuid
+
+from .supervised_ui_contract import (
+    CONTRACT_VERSION,
+    TRAINING_PROTOCOL_COMMIT,
+    canonical_json_bytes,
+    sha256_hex,
+)
+
+
+_EVENT_KIND_RE = re.compile(r'^[a-z][a-z0-9_]{0,63}$')
+_UUID_RE = re.compile(
+    r'^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+)
+_SHA256_RE = re.compile(r'^[0-9a-f]{64}$')
+_GIT_COMMIT_RE = re.compile(r'^(?:[0-9a-f]{40}|[0-9a-f]{64})$')
+_RECEIPT_RE = re.compile(r'^(\d{6})-([a-z][a-z0-9_]{0,63})\.(json|raw)$')
+_TERMINAL_EXECUTION_KINDS = frozenset({
+    'action_result_exact',
+    'failed',
+    'indeterminate',
+    'replayed',
+    'stale',
+    'tool_result_exact',
+})
+
+
+class ReceiptStoreError(RuntimeError):
+    pass
+
+
+def _uuid_text(value: Any, context: str, *, optional: bool = False) -> str | None:
+    if optional and value is None:
+        return None
+    if not isinstance(value, str) or not _UUID_RE.fullmatch(value):
+        raise ReceiptStoreError(f'{context} must be a lowercase UUID')
+    return value
+
+
+def _assert_no_symlink_components(path: Path) -> None:
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current = current / part
+        try:
+            metadata = os.lstat(current)
+        except FileNotFoundError as exc:
+            raise ReceiptStoreError(f'receipt path component does not exist: {current}') from exc
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ReceiptStoreError(f'receipt path component is a symlink: {current}')
+
+
+def _validate_external_root(root: str | os.PathLike[str], public_repo_roots: list[str]) -> Path:
+    raw_root = Path(root)
+    if not raw_root.is_absolute():
+        raise ReceiptStoreError('receipt root must be absolute')
+    _assert_no_symlink_components(raw_root)
+    metadata = os.lstat(raw_root)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise ReceiptStoreError('receipt root must be a directory')
+    if stat.S_IMODE(metadata.st_mode) != 0o700:
+        raise ReceiptStoreError('receipt root mode must be exactly 0700')
+    if metadata.st_uid != os.getuid():
+        raise ReceiptStoreError('receipt root must be owned by the worker user')
+    resolved_root = raw_root.resolve(strict=True)
+    if not public_repo_roots:
+        raise ReceiptStoreError('at least one public repository root is required')
+    for raw_public_root in public_repo_roots:
+        public_root = Path(raw_public_root)
+        if not public_root.is_absolute():
+            raise ReceiptStoreError('public repository roots must be absolute')
+        _assert_no_symlink_components(public_root)
+        resolved_public = public_root.resolve(strict=True)
+        if resolved_root == resolved_public or resolved_public in resolved_root.parents:
+            raise ReceiptStoreError('receipt root must be outside every public repository')
+    return resolved_root
+
+
+def _write_all(fd: int, raw_bytes: bytes) -> None:
+    view = memoryview(raw_bytes)
+    written = 0
+    while written < len(view):
+        count = os.write(fd, view[written:])
+        if count <= 0:
+            raise ReceiptStoreError('receipt write made no progress')
+        written += count
+
+
+class HandsReceiptStore:
+    def __init__(
+        self,
+        *,
+        root: Path,
+        session_dir: Path,
+        session_id: str,
+        presence_incarnation_id: str,
+        hands_incarnation_id: str,
+        hands_commit: str,
+        dir_fd: int,
+        lock_fd: int,
+        events: list[dict[str, Any]],
+    ) -> None:
+        self.root = root
+        self.session_dir = session_dir
+        self.session_id = session_id
+        self.presence_incarnation_id = presence_incarnation_id
+        self.hands_incarnation_id = hands_incarnation_id
+        self.hands_commit = hands_commit
+        self._dir_fd = dir_fd
+        self._lock_fd = lock_fd
+        self._events = events
+        self._broken = False
+
+    @classmethod
+    def open_external(
+        cls,
+        root: str | os.PathLike[str],
+        public_repo_roots: list[str],
+        *,
+        session_id: str,
+        presence_incarnation_id: str,
+        hands_incarnation_id: str,
+        hands_commit: str,
+    ) -> 'HandsReceiptStore':
+        _uuid_text(session_id, 'session_id')
+        _uuid_text(presence_incarnation_id, 'presence_incarnation_id')
+        _uuid_text(hands_incarnation_id, 'hands_incarnation_id')
+        if not isinstance(hands_commit, str) or not _GIT_COMMIT_RE.fullmatch(hands_commit):
+            raise ReceiptStoreError('hands_commit must be an exact commit SHA')
+        validated_root = _validate_external_root(root, public_repo_roots)
+        session_dir = validated_root / session_id
+        try:
+            os.mkdir(session_dir, mode=0o700)
+            root_fd = os.open(
+                validated_root,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            )
+            try:
+                os.fsync(root_fd)
+            finally:
+                os.close(root_fd)
+        except FileExistsError:
+            pass
+        session_metadata = os.lstat(session_dir)
+        if stat.S_ISLNK(session_metadata.st_mode) or not stat.S_ISDIR(session_metadata.st_mode):
+            raise ReceiptStoreError('session receipt path must be a real directory')
+        if stat.S_IMODE(session_metadata.st_mode) != 0o700:
+            raise ReceiptStoreError('session receipt directory mode must be exactly 0700')
+        if session_metadata.st_uid != os.getuid():
+            raise ReceiptStoreError('session receipt directory must be owned by the worker user')
+        dir_fd = os.open(
+            session_dir,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+        )
+        lock_fd = -1
+        try:
+            lock_fd = os.open(
+                '.worker.lock',
+                os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW | os.O_CLOEXEC,
+                0o600,
+                dir_fd=dir_fd,
+            )
+            os.fchmod(lock_fd, 0o600)
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError as exc:
+                raise ReceiptStoreError('another worker owns this supervised session') from exc
+            events = cls._load_and_verify_events(
+                dir_fd=dir_fd,
+                session_id=session_id,
+            )
+            return cls(
+                root=validated_root,
+                session_dir=session_dir,
+                session_id=session_id,
+                presence_incarnation_id=presence_incarnation_id,
+                hands_incarnation_id=hands_incarnation_id,
+                hands_commit=hands_commit,
+                dir_fd=dir_fd,
+                lock_fd=lock_fd,
+                events=events,
+            )
+        except Exception:
+            if lock_fd >= 0:
+                os.close(lock_fd)
+            os.close(dir_fd)
+            raise
+
+    @staticmethod
+    def _read_file(dir_fd: int, filename: str) -> bytes:
+        fd = os.open(
+            filename,
+            os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=dir_fd,
+        )
+        try:
+            metadata = os.fstat(fd)
+            if not stat.S_ISREG(metadata.st_mode) or stat.S_IMODE(metadata.st_mode) != 0o600:
+                raise ReceiptStoreError(f'unsafe receipt artifact {filename}')
+            chunks: list[bytes] = []
+            while True:
+                chunk = os.read(fd, 1024 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            return b''.join(chunks)
+        finally:
+            os.close(fd)
+
+    @classmethod
+    def _load_and_verify_events(
+        cls,
+        *,
+        dir_fd: int,
+        session_id: str,
+    ) -> list[dict[str, Any]]:
+        names = sorted(name for name in os.listdir(dir_fd) if name != '.worker.lock')
+        if any(_RECEIPT_RE.fullmatch(name) is None for name in names):
+            raise ReceiptStoreError('session receipt directory contains an unknown artifact')
+        grouped: dict[tuple[int, str], set[str]] = {}
+        for name in names:
+            match = _RECEIPT_RE.fullmatch(name)
+            assert match is not None
+            key = (int(match.group(1)), match.group(2))
+            grouped.setdefault(key, set()).add(match.group(3))
+        events: list[dict[str, Any]] = []
+        prior_hash: str | None = None
+        prior_event_id: str | None = None
+        for expected_sequence, ((sequence, kind), suffixes) in enumerate(sorted(grouped.items()), 1):
+            if sequence != expected_sequence or suffixes != {'json', 'raw'}:
+                raise ReceiptStoreError('receipt sequence is incomplete or noncontiguous')
+            prefix = f'{sequence:06d}-{kind}'
+            raw_bytes = cls._read_file(dir_fd, f'{prefix}.raw')
+            metadata_bytes = cls._read_file(dir_fd, f'{prefix}.json')
+            try:
+                event = json.loads(metadata_bytes.decode('utf-8'))
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise ReceiptStoreError('receipt metadata is not UTF-8 JSON') from exc
+            if not isinstance(event, dict) or canonical_json_bytes(event) != metadata_bytes:
+                raise ReceiptStoreError('receipt metadata is not canonical JSON')
+            event_hash = event.get('event_hash')
+            unsigned = dict(event)
+            unsigned.pop('event_hash', None)
+            if not isinstance(event_hash, str) or not _SHA256_RE.fullmatch(event_hash):
+                raise ReceiptStoreError('receipt event hash is invalid')
+            if sha256_hex(canonical_json_bytes(unsigned)) != event_hash:
+                raise ReceiptStoreError('receipt event hash mismatch')
+            checks = {
+                event.get('schema_version') == CONTRACT_VERSION,
+                event.get('session_id') == session_id,
+                event.get('sequence') == sequence,
+                event.get('kind') == kind,
+                event.get('prior_event_hash') == prior_hash,
+                event.get('caused_by_event_id') == prior_event_id,
+                event.get('payload_sha256') == sha256_hex(raw_bytes),
+                event.get('raw_artifact') == f'{prefix}.raw',
+            }
+            commits = event.get('public_repository_commits')
+            if not isinstance(commits, dict) or frozenset(commits) != frozenset({
+                'palios-taey/palios-training',
+                'palios-taey/taeys-hands',
+            }):
+                raise ReceiptStoreError('receipt repository provenance is invalid')
+            if commits['palios-taey/palios-training'] != TRAINING_PROTOCOL_COMMIT:
+                raise ReceiptStoreError('receipt training protocol provenance changed')
+            if not isinstance(commits['palios-taey/taeys-hands'], str) or not _GIT_COMMIT_RE.fullmatch(
+                commits['palios-taey/taeys-hands']
+            ):
+                raise ReceiptStoreError('receipt Hands commit provenance is invalid')
+            if False in checks:
+                raise ReceiptStoreError('receipt causal chain verification failed')
+            _uuid_text(event.get('event_id'), 'receipt.event_id')
+            _uuid_text(event.get('hands_incarnation_id'), 'receipt.hands_incarnation_id')
+            _uuid_text(event.get('presence_incarnation_id'), 'receipt.presence_incarnation_id')
+            try:
+                payload = json.loads(raw_bytes.decode('utf-8'))
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise ReceiptStoreError('Hands receipt payload is not UTF-8 JSON') from exc
+            event['_payload'] = payload
+            events.append(event)
+            prior_hash = event_hash
+            prior_event_id = event['event_id']
+        return events
+
+    @property
+    def events(self) -> tuple[Mapping[str, Any], ...]:
+        return tuple(
+            {key: value for key, value in event.items() if key != '_payload'}
+            for event in self._events
+        )
+
+    @property
+    def last_event_id(self) -> str | None:
+        return self._events[-1]['event_id'] if self._events else None
+
+    def _create_file(self, filename: str, raw_bytes: bytes) -> None:
+        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW | os.O_CLOEXEC
+        fd = os.open(filename, flags, 0o600, dir_fd=self._dir_fd)
+        try:
+            os.fchmod(fd, 0o600)
+            _write_all(fd, raw_bytes)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        os.fsync(self._dir_fd)
+
+    def write_once(self, event: Mapping[str, Any], raw_bytes: bytes) -> Mapping[str, Any]:
+        if self._broken:
+            raise ReceiptStoreError('receipt store is terminal after a prior write failure')
+        if not isinstance(raw_bytes, bytes) or not raw_bytes:
+            raise ReceiptStoreError('receipt raw bytes must be nonempty')
+        supplied = dict(event)
+        required = frozenset({
+            'approval_id',
+            'event_id',
+            'execution_id',
+            'kind',
+            'observation_id',
+            'proposal_id',
+            'turn_id',
+        })
+        if frozenset(supplied) != required:
+            raise ReceiptStoreError('receipt event fields are incomplete or unknown')
+        kind = supplied['kind']
+        if not isinstance(kind, str) or not _EVENT_KIND_RE.fullmatch(kind):
+            raise ReceiptStoreError('receipt event kind is invalid')
+        _uuid_text(supplied['event_id'], 'event_id')
+        for key in ('approval_id', 'execution_id', 'observation_id', 'proposal_id', 'turn_id'):
+            _uuid_text(supplied[key], key, optional=True)
+        sequence = len(self._events) + 1
+        prefix = f'{sequence:06d}-{kind}'
+        raw_filename = f'{prefix}.raw'
+        metadata_filename = f'{prefix}.json'
+        names = set(os.listdir(self._dir_fd))
+        if raw_filename in names or metadata_filename in names:
+            raise ReceiptStoreError('receipt filename collision')
+        unsigned = {
+            'approval_id': supplied['approval_id'],
+            'caused_by_event_id': self.last_event_id,
+            'event_id': supplied['event_id'],
+            'execution_id': supplied['execution_id'],
+            'hands_incarnation_id': self.hands_incarnation_id,
+            'kind': kind,
+            'monotonic_ns': time.monotonic_ns(),
+            'observation_id': supplied['observation_id'],
+            'payload_sha256': hashlib.sha256(raw_bytes).hexdigest(),
+            'prior_event_hash': self._events[-1]['event_hash'] if self._events else None,
+            'presence_incarnation_id': self.presence_incarnation_id,
+            'proposal_id': supplied['proposal_id'],
+            'public_repository_commits': {
+                'palios-taey/palios-training': TRAINING_PROTOCOL_COMMIT,
+                'palios-taey/taeys-hands': self.hands_commit,
+            },
+            'raw_artifact': raw_filename,
+            'recorded_at': datetime.now(timezone.utc).isoformat(timespec='microseconds'),
+            'schema_version': CONTRACT_VERSION,
+            'sequence': sequence,
+            'session_id': self.session_id,
+            'turn_id': supplied['turn_id'],
+        }
+        recorded = dict(unsigned)
+        recorded['event_hash'] = sha256_hex(canonical_json_bytes(unsigned))
+        try:
+            self._create_file(raw_filename, raw_bytes)
+            self._create_file(metadata_filename, canonical_json_bytes(recorded))
+        except Exception:
+            self._broken = True
+            raise
+        internal = dict(recorded)
+        internal['_payload'] = json.loads(raw_bytes.decode('utf-8'))
+        self._events.append(internal)
+        return dict(recorded)
+
+    def has_approval_spend(self, approval_id: str) -> bool:
+        return any(
+            event['kind'] == 'approval_spent' and event['approval_id'] == approval_id
+            for event in self._events
+        )
+
+    def has_execution(self, execution_id: str) -> bool:
+        return any(event['execution_id'] == execution_id for event in self._events)
+
+    def recover_incarnation(self) -> str:
+        executions: dict[str, list[Mapping[str, Any]]] = {}
+        for event in self._events:
+            execution_id = event.get('execution_id')
+            if execution_id is not None:
+                executions.setdefault(execution_id, []).append(event)
+        for execution_id, events in sorted(executions.items()):
+            kinds = {event['kind'] for event in events}
+            if not kinds.intersection({'approval_spent', 'execution_started'}):
+                continue
+            if kinds.intersection(_TERMINAL_EXECUTION_KINDS):
+                continue
+            last = events[-1]
+            payload = canonical_json_bytes({
+                'reason': 'recovered_incomplete_execution',
+                'prior_hands_incarnation_id': last['hands_incarnation_id'],
+            })
+            self.write_once({
+                'approval_id': last.get('approval_id'),
+                'event_id': str(uuid.uuid4()),
+                'execution_id': execution_id,
+                'kind': 'indeterminate',
+                'observation_id': last.get('observation_id'),
+                'proposal_id': last.get('proposal_id'),
+                'turn_id': last.get('turn_id'),
+            }, payload)
+        return self.hands_incarnation_id
+
+    def close(self) -> None:
+        if self._lock_fd >= 0:
+            fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
+            os.close(self._lock_fd)
+            self._lock_fd = -1
+        if self._dir_fd >= 0:
+            os.close(self._dir_fd)
+            self._dir_fd = -1
+
+    def __enter__(self) -> 'HandsReceiptStore':
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        self.close()

--- a/consultation_v2/supervised_ui_seat.py
+++ b/consultation_v2/supervised_ui_seat.py
@@ -1,0 +1,557 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import hmac
+from typing import Any, Mapping
+import uuid
+
+from .interact import atspi_activate, atspi_focus
+from .snapshot import build_snapshot
+from .supervised_ui_contract import (
+    CONTRACT_VERSION,
+    ProjectedSnapshot,
+    SupervisedUiContractError,
+    build_live_ui_action_schema,
+    canonical_json_bytes,
+    load_supervised_policy,
+    project_snapshot,
+    snapshot_revision,
+    validate_approved_call,
+)
+from .supervised_ui_receipts import HandsReceiptStore, ReceiptStoreError
+
+
+_TERMINAL_STATES = frozenset({
+    'cancelled',
+    'failed',
+    'indeterminate',
+    'rejected',
+    'replayed',
+    'stale',
+})
+
+
+class SupervisedUiSeatError(RuntimeError):
+    def __init__(self, refusal_class: str) -> None:
+        super().__init__(refusal_class)
+        self.refusal_class = refusal_class
+
+
+def _parse_expiry(value: Any, context: str) -> datetime:
+    if not isinstance(value, str):
+        raise SupervisedUiSeatError(f'{context}_invalid')
+    try:
+        parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except ValueError as exc:
+        raise SupervisedUiSeatError(f'{context}_invalid') from exc
+    if parsed.tzinfo is None:
+        raise SupervisedUiSeatError(f'{context}_invalid')
+    return parsed.astimezone(timezone.utc)
+
+
+class SupervisedUiSeat:
+    def __init__(
+        self,
+        *,
+        platform: str,
+        lease_secret: bytes,
+        lease_expires_at: str,
+        presence_incarnation_id: str,
+        hands_incarnation_id: str,
+        hands_commit: str,
+        receipt_store: HandsReceiptStore,
+    ) -> None:
+        if not isinstance(lease_secret, bytes) or len(lease_secret) < 32:
+            raise SupervisedUiSeatError('lease_secret_invalid')
+        load_supervised_policy(platform)
+        self.platform = platform
+        self._lease_secret = lease_secret
+        self._lease_expires_at = _parse_expiry(lease_expires_at, 'lease_expiry')
+        self.presence_incarnation_id = presence_incarnation_id
+        self.hands_incarnation_id = hands_incarnation_id
+        self.hands_commit = hands_commit
+        self.receipts = receipt_store
+        if self.receipts.hands_incarnation_id != hands_incarnation_id:
+            raise SupervisedUiSeatError('receipt_incarnation_mismatch')
+        if self.receipts.presence_incarnation_id != presence_incarnation_id:
+            raise SupervisedUiSeatError('receipt_presence_incarnation_mismatch')
+        self.receipts.recover_incarnation()
+        self.state = 'needs_observe'
+        self._projection: ProjectedSnapshot | None = None
+        self._revision: str | None = None
+        self._observation_id: str | None = None
+        self._pending_verification: dict[str, Any] | None = None
+        self._last_approval: Mapping[str, Any] | None = None
+        self._closed = False
+        self._handshake_recorded = False
+        self._record(
+            'worker_started',
+            {
+                'contract_version': CONTRACT_VERSION,
+                'hands_commit': hands_commit,
+                'hands_incarnation_id': hands_incarnation_id,
+                'presence_incarnation_id': presence_incarnation_id,
+            },
+        )
+
+    def _record(
+        self,
+        kind: str,
+        payload: Mapping[str, Any],
+        *,
+        approval: Mapping[str, Any] | None = None,
+        observation_id: str | None = None,
+    ) -> Mapping[str, Any]:
+        approval = dict(approval or {})
+        return self.receipts.write_once({
+            'approval_id': approval.get('approval_id'),
+            'event_id': str(uuid.uuid4()),
+            'execution_id': approval.get('execution_id'),
+            'kind': kind,
+            'observation_id': (
+                observation_id
+                if observation_id is not None
+                else approval.get('observation_id')
+            ),
+            'proposal_id': approval.get('proposal_id'),
+            'turn_id': approval.get('turn_id'),
+        }, canonical_json_bytes(payload))
+
+    def _assert_open(self) -> None:
+        if self._closed:
+            raise SupervisedUiSeatError('worker_closed')
+        if self.state in _TERMINAL_STATES:
+            raise SupervisedUiSeatError(f'session_terminal_{self.state}')
+
+    def _assert_lease_live(self) -> None:
+        if datetime.now(timezone.utc) >= self._lease_expires_at:
+            self.state = 'failed'
+            raise SupervisedUiSeatError('lease_expired')
+
+    def _schema(self) -> Mapping[str, Any] | None:
+        if self.state in _TERMINAL_STATES:
+            return None
+        try:
+            return build_live_ui_action_schema(
+                self.state,
+                self._projection,
+                self._revision,
+            )
+        except SupervisedUiContractError:
+            return None
+
+    def handshake(self) -> Mapping[str, Any]:
+        if self._handshake_recorded:
+            raise SupervisedUiSeatError('handshake_already_recorded')
+        result = {
+            'contract_version': CONTRACT_VERSION,
+            'hands_commit': self.hands_commit,
+            'hands_incarnation_id': self.hands_incarnation_id,
+            'state': self.state,
+            'tool': self._schema(),
+        }
+        self._record('worker_handshake', result)
+        self._handshake_recorded = True
+        return result
+
+    def _capture_projection(self) -> tuple[ProjectedSnapshot, str]:
+        _firefox, _document, snapshot = build_snapshot(self.platform)
+        projected = project_snapshot(snapshot, self._lease_secret)
+        revision = snapshot_revision(projected, self._lease_secret)
+        return projected, revision
+
+    def _validate_authority(
+        self,
+        proposal_bytes: bytes,
+        approval: Mapping[str, Any],
+        capability_secret: bytes,
+    ) -> dict[str, Any]:
+        self._assert_open()
+        self._assert_lease_live()
+        if not isinstance(capability_secret, bytes) or len(capability_secret) < 32:
+            raise SupervisedUiSeatError('capability_invalid')
+        try:
+            proposal = validate_approved_call(
+                proposal_bytes,
+                approval,
+                self._projection,
+            )
+        except SupervisedUiContractError as exc:
+            raise SupervisedUiSeatError('proposal_approval_mismatch') from exc
+        if approval['hands_incarnation_id'] != self.hands_incarnation_id:
+            raise SupervisedUiSeatError('hands_incarnation_mismatch')
+        if approval['presence_incarnation_id'] != self.presence_incarnation_id:
+            raise SupervisedUiSeatError('presence_incarnation_mismatch')
+        approval_expiry = _parse_expiry(approval['expires_at'], 'approval_expiry')
+        if approval_expiry > self._lease_expires_at:
+            raise SupervisedUiSeatError('approval_exceeds_lease')
+        if approval_expiry <= datetime.now(timezone.utc):
+            raise SupervisedUiSeatError('approval_expired')
+        capability_digest = hashlib.sha256(capability_secret).hexdigest()
+        if not hmac.compare_digest(capability_digest, approval['capability_sha256']):
+            raise SupervisedUiSeatError('capability_digest_mismatch')
+        if self.receipts.has_approval_spend(approval['approval_id']):
+            self.state = 'replayed'
+            raise SupervisedUiSeatError('approval_replayed')
+        if self.receipts.has_execution(approval['execution_id']):
+            self.state = 'replayed'
+            raise SupervisedUiSeatError('execution_replayed')
+        operation = proposal['op']
+        allowed_by_state = {
+            'needs_observe': frozenset({'observe'}),
+            'needs_verify': frozenset({'verify'}),
+            'action_ready': frozenset({'activate', 'focus'}),
+        }.get(self.state, frozenset())
+        if operation not in allowed_by_state:
+            raise SupervisedUiSeatError('operation_invalid_for_state')
+        if operation in {'activate', 'focus'}:
+            if approval['revision'] != self._revision:
+                raise SupervisedUiSeatError('approval_revision_mismatch')
+            if approval['observation_id'] != self._observation_id:
+                raise SupervisedUiSeatError('approval_observation_mismatch')
+        return proposal
+
+    def _record_projection_omissions(
+        self,
+        projected: ProjectedSnapshot,
+        approval: Mapping[str, Any],
+        observation_id: str,
+    ) -> None:
+        for omission in projected.omissions:
+            self._record(
+                'projection_omission',
+                omission,
+                approval=approval,
+                observation_id=observation_id,
+            )
+
+    def _spend_and_start(
+        self,
+        proposal_bytes: bytes,
+        approval: Mapping[str, Any],
+    ) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+        spend_payload = {
+            'actor_id': approval['actor_id'],
+            'approval_id': approval['approval_id'],
+            'capability_sha256': approval['capability_sha256'],
+            'effect_class': approval['effect_class'],
+            'operation': approval['operation'],
+            'presence_incarnation_id': approval['presence_incarnation_id'],
+            'proposal_sha256': hashlib.sha256(proposal_bytes).hexdigest(),
+            'ref': approval['ref'],
+            'revision': approval['revision'],
+        }
+        spent = self._record('approval_spent', spend_payload, approval=approval)
+        started = self._record(
+            'execution_started',
+            {
+                'approval_event_hash': spent['event_hash'],
+                'execution_id': approval['execution_id'],
+                'operation': approval['operation'],
+            },
+            approval=approval,
+        )
+        return spent, started
+
+    def _fail_after_start(
+        self,
+        approval: Mapping[str, Any],
+        refusal_class: str,
+    ) -> None:
+        self.state = 'indeterminate'
+        try:
+            self._record(
+                'indeterminate',
+                {'reason': refusal_class},
+                approval=approval,
+            )
+        except Exception:
+            pass
+
+    def _observe_after_start(
+        self,
+        operation: str,
+        approval: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        observation_id = str(uuid.uuid4())
+        projected, revision = self._capture_projection()
+        self._record_projection_omissions(projected, approval, observation_id)
+        outcome = self._record(
+            'execution_outcome',
+            {
+                'operation': operation,
+                'success': True,
+            },
+            approval=approval,
+            observation_id=observation_id,
+        )
+        observation_payload = {
+            **projected.public,
+            'observation_id': observation_id,
+            'revision': revision,
+        }
+        observation_kind = (
+            'post_action_observation_exact'
+            if operation == 'verify'
+            else 'observation_exact'
+        )
+        observation_event = self._record(
+            observation_kind,
+            observation_payload,
+            approval=approval,
+            observation_id=observation_id,
+        )
+        verification: Mapping[str, Any] | None = None
+        if operation == 'verify':
+            verification = self._verify_postcondition(projected, revision, approval)
+            self._record(
+                'verification_verdict',
+                verification,
+                approval=approval,
+                observation_id=observation_id,
+            )
+        self._projection = projected
+        self._revision = revision
+        self._observation_id = observation_id
+        if verification is not None and not verification['passed']:
+            self.state = 'failed'
+        elif projected.public['elements']:
+            self.state = 'action_ready'
+        else:
+            self.state = 'failed'
+        result: dict[str, Any] = {
+            'execution_event_hash': outcome['event_hash'],
+            'next_required': self.state,
+            'observation': observation_payload,
+            'observation_event_hash': observation_event['event_hash'],
+            'state': self.state,
+            'tool': self._schema(),
+        }
+        if verification is not None:
+            result['verification'] = verification
+        self._record(
+            'tool_result_exact',
+            result,
+            approval=approval,
+            observation_id=observation_id,
+        )
+        return result
+
+    def _verify_postcondition(
+        self,
+        projected: ProjectedSnapshot,
+        after_revision: str,
+        approval: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        pending = self._pending_verification
+        if pending is None:
+            raise SupervisedUiSeatError('verification_without_action')
+        ref = pending['ref']
+        element = next(
+            (item for item in projected.public['elements'] if item['ref'] == ref),
+            None,
+        )
+        policy = load_supervised_policy(self.platform)
+        control = next(
+            (
+                item for item in policy.controls.values()
+                if item.control_id == pending['control_id']
+            ),
+            None,
+        )
+        if control is None:
+            raise SupervisedUiSeatError('verification_policy_missing')
+        postcondition = control.postconditions[pending['operation']]
+        observed_states = set(element['states']) if element is not None else set()
+        required_states = set(postcondition['states_include'])
+        forbidden_states = set(postcondition['states_exclude'])
+        passed = (
+            element is not None
+            and required_states.issubset(observed_states)
+            and forbidden_states.isdisjoint(observed_states)
+        )
+        result = {
+            'action_execution_event_hash': pending['execution_event_hash'],
+            'after_revision': after_revision,
+            'before_revision': pending['before_revision'],
+            'forbidden_states': sorted(forbidden_states),
+            'observed_states': sorted(observed_states),
+            'operation': pending['operation'],
+            'passed': passed,
+            'ref': ref,
+            'required_states': sorted(required_states),
+            'verification_execution_id': approval['execution_id'],
+        }
+        self._pending_verification = None
+        return result
+
+    def _execute_action_after_start(
+        self,
+        proposal: Mapping[str, Any],
+        approval: Mapping[str, Any],
+        projected: ProjectedSnapshot,
+    ) -> Mapping[str, Any]:
+        ref = proposal['ref']
+        element = projected.bindings[ref]
+        if proposal['op'] == 'focus':
+            success = atspi_focus(element.raw)
+        elif proposal['op'] == 'activate':
+            success = atspi_activate(element.raw)
+        else:
+            raise SupervisedUiSeatError('action_operation_invalid')
+        outcome = self._record(
+            'execution_outcome',
+            {
+                'operation': proposal['op'],
+                'success': bool(success),
+            },
+            approval=approval,
+        )
+        if not success:
+            self.state = 'failed'
+            result = {
+                'execution_event_hash': outcome['event_hash'],
+                'next_required': 'failed',
+                'operation': proposal['op'],
+                'primitive_success': False,
+                'ref': ref,
+                'revision': proposal['revision'],
+                'state': self.state,
+            }
+            self._record('action_result_exact', result, approval=approval)
+            return result
+        public_element = next(item for item in projected.public['elements'] if item['ref'] == ref)
+        self._pending_verification = {
+            'before_revision': proposal['revision'],
+            'control_id': public_element['control_id'],
+            'execution_event_hash': outcome['event_hash'],
+            'operation': proposal['op'],
+            'ref': ref,
+        }
+        self.state = 'needs_verify'
+        result = {
+            'execution_event_hash': outcome['event_hash'],
+            'next_required': 'needs_verify',
+            'operation': proposal['op'],
+            'primitive_success': True,
+            'ref': ref,
+            'revision': proposal['revision'],
+            'state': self.state,
+            'tool': self._schema(),
+        }
+        self._record('action_result_exact', result, approval=approval)
+        self._record(
+            'state_needs_verify',
+            {
+                'action_execution_event_hash': outcome['event_hash'],
+                'input_revision': proposal['revision'],
+            },
+            approval=approval,
+        )
+        return result
+
+    def execute_approved(
+        self,
+        proposal_bytes: bytes,
+        approval: Mapping[str, Any],
+        capability_secret: bytes,
+    ) -> Mapping[str, Any]:
+        try:
+            proposal = self._validate_authority(proposal_bytes, approval, capability_secret)
+        except SupervisedUiSeatError:
+            if self.state not in _TERMINAL_STATES:
+                self.state = 'rejected'
+            raise
+        self._last_approval = dict(approval)
+        operation = proposal['op']
+        fresh_projection: ProjectedSnapshot | None = None
+        if operation in {'activate', 'focus'}:
+            try:
+                fresh_projection, fresh_revision = self._capture_projection()
+            except Exception as exc:
+                self.state = 'failed'
+                raise SupervisedUiSeatError('stale_check_failed') from exc
+            stale_observation_id = str(uuid.uuid4())
+            self._record(
+                'stale_check_observation_exact',
+                {
+                    **fresh_projection.public,
+                    'observation_id': stale_observation_id,
+                    'revision': fresh_revision,
+                },
+                approval=approval,
+                observation_id=stale_observation_id,
+            )
+            if fresh_revision != proposal['revision'] or proposal['ref'] not in fresh_projection.bindings:
+                self.state = 'stale'
+                self._record(
+                    'stale',
+                    {
+                        'actual_revision': fresh_revision,
+                        'expected_revision': proposal['revision'],
+                        'ref_present': proposal['ref'] in fresh_projection.bindings,
+                    },
+                    approval=approval,
+                    observation_id=stale_observation_id,
+                )
+                raise SupervisedUiSeatError('stale_projection')
+        try:
+            self._spend_and_start(proposal_bytes, approval)
+        except Exception:
+            if self.receipts.has_approval_spend(approval['approval_id']):
+                self._fail_after_start(approval, 'execution_start_not_durable')
+            else:
+                self.state = 'failed'
+            raise
+        try:
+            if operation in {'observe', 'verify'}:
+                return self._observe_after_start(operation, approval)
+            assert fresh_projection is not None
+            return self._execute_action_after_start(proposal, approval, fresh_projection)
+        except (SupervisedUiSeatError, ReceiptStoreError):
+            self._fail_after_start(approval, 'execution_incomplete')
+            raise
+        except BaseException:
+            self._fail_after_start(approval, 'worker_interrupted_after_start')
+            raise
+
+    def cancel(self) -> Mapping[str, Any]:
+        self._assert_open()
+        self.state = 'cancelled'
+        receipt = self._record('cancelled', {'reason': 'supervisor_cancelled'})
+        return {'event_hash': receipt['event_hash'], 'state': self.state}
+
+    def reject_protocol(self, refusal_class: str) -> Mapping[str, Any]:
+        self._assert_open()
+        self.state = 'rejected'
+        receipt = self._record(
+            'proposal_rejected',
+            {'refusal_class': refusal_class},
+        )
+        return {'event_hash': receipt['event_hash'], 'state': self.state}
+
+    def mark_response_loss(self) -> None:
+        if self._closed:
+            return
+        self.state = 'indeterminate'
+        try:
+            self._record(
+                'indeterminate',
+                {'reason': 'response_delivery_lost'},
+                approval=self._last_approval,
+            )
+        except Exception:
+            pass
+
+    def close(self) -> Mapping[str, Any]:
+        if self._closed:
+            raise SupervisedUiSeatError('worker_closed')
+        receipt = self._record('worker_closed', {'final_state': self.state})
+        self._closed = True
+        self.receipts.close()
+        return {'event_hash': receipt['event_hash'], 'state': self.state}
+
+    @property
+    def closed(self) -> bool:
+        return self._closed

--- a/consultation_v2/validators/lint_consultation_v2_contract.py
+++ b/consultation_v2/validators/lint_consultation_v2_contract.py
@@ -120,6 +120,30 @@ def scan_yaml_schema(path: Path, source: str) -> list[Finding]:
                 line.rstrip(),
             ))
 
+    if data.get('schema') == 'supervised_ui_policy_v1':
+        if path.name != 'supervised_ui.yaml':
+            findings.append(Finding(
+                str(path), 1, 'supervised-ui-policy-path',
+                'supervised UI policy must use the package-owned supervised_ui.yaml path',
+            ))
+            return findings
+        try:
+            repository_root = str(Path(__file__).resolve().parents[2])
+            if repository_root not in sys.path:
+                sys.path.insert(0, repository_root)
+            from consultation_v2.supervised_ui_contract import (
+                clear_supervised_policy_cache,
+                load_supervised_policy,
+            )
+            clear_supervised_policy_cache()
+            load_supervised_policy(path.parent.name)
+        except Exception as exc:
+            findings.append(Finding(
+                str(path), 1, 'supervised-ui-policy-invalid',
+                f'{type(exc).__name__}: {exc}',
+            ))
+        return findings
+
     if is_consultation_v2_yaml(path):
         settle = data.get('settle')
         if not isinstance(settle, dict):

--- a/scripts/run_supervised_ui_seat.py
+++ b/scripts/run_supervised_ui_seat.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import base64
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import re
+import signal
+import stat
+import subprocess
+import sys
+from typing import Any, Mapping
+import uuid
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+_DISPLAY_RE = re.compile(r'^:[0-9]{1,3}$')
+_GIT_COMMIT_RE = re.compile(r'^(?:[0-9a-f]{40}|[0-9a-f]{64})$')
+_REQUEST_LIMIT = 1024 * 1024
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description='Run the approval-gated supervised Taey UI Hands worker.',
+    )
+    parser.add_argument(
+        '--platform',
+        required=True,
+        choices=['chatgpt', 'claude', 'gemini', 'grok', 'perplexity'],
+    )
+    parser.add_argument('--display', required=True)
+    parser.add_argument('--receipt-root', required=True)
+    parser.add_argument('--session-id', required=True)
+    parser.add_argument('--presence-incarnation-id', required=True)
+    parser.add_argument('--lease-expires-at', required=True)
+    parser.add_argument('--lease-secret-env', required=True)
+    parser.add_argument('--hands-commit', required=True)
+    parser.add_argument('--public-repo-root', action='append', required=True)
+    parser.add_argument('--lock-wait-seconds', type=float, default=0.0)
+    return parser
+
+
+def _strict_json(raw_text: str) -> dict[str, Any]:
+    def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        value: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in value:
+                raise ValueError('duplicate key')
+            value[key] = item
+        return value
+
+    parsed = json.loads(
+        raw_text,
+        object_pairs_hook=reject_duplicates,
+        parse_constant=lambda _value: (_ for _ in ()).throw(ValueError('non-JSON constant')),
+    )
+    if not isinstance(parsed, dict):
+        raise ValueError('request must be an object')
+    return parsed
+
+
+def _require_keys(value: Mapping[str, Any], required: frozenset[str]) -> None:
+    if frozenset(value) != required:
+        raise ValueError('request fields are incomplete or unknown')
+
+
+def _uuid_text(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValueError('request_id must be a UUID')
+    parsed = uuid.UUID(value)
+    if str(parsed) != value:
+        raise ValueError('request_id must be a lowercase canonical UUID')
+    return value
+
+
+def _decode_b64(value: Any, context: str, *, minimum: int = 1) -> bytes:
+    if not isinstance(value, str):
+        raise ValueError(f'{context} must be base64')
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except ValueError as exc:
+        raise ValueError(f'{context} must be base64') from exc
+    if len(decoded) < minimum:
+        raise ValueError(f'{context} is too short')
+    return decoded
+
+
+def _bind_display(display: str) -> None:
+    if not _DISPLAY_RE.fullmatch(display):
+        raise RuntimeError('display must use the :N form')
+    bus_path = Path('/tmp') / f'a11y_bus_{display}'
+    descriptor = os.open(bus_path, os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC)
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise RuntimeError('AT-SPI bus binding must be a regular nonsymlink file')
+        bus = os.read(descriptor, 4096).decode('utf-8').strip()
+        if os.read(descriptor, 1):
+            raise RuntimeError('AT-SPI bus binding is unexpectedly large')
+    finally:
+        os.close(descriptor)
+    if not bus:
+        raise RuntimeError('AT-SPI bus binding is empty')
+    os.environ['DISPLAY'] = display
+    os.environ['AT_SPI_BUS_ADDRESS'] = bus
+
+
+def _current_commit() -> str:
+    completed = subprocess.run(
+        ['git', '-C', str(REPO_ROOT), 'rev-parse', 'HEAD'],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    commit = completed.stdout.strip()
+    if not _GIT_COMMIT_RE.fullmatch(commit):
+        raise RuntimeError('unable to establish exact Hands commit')
+    return commit
+
+
+def _lease_runtime_seconds(value: str) -> float:
+    parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
+    if parsed.tzinfo is None:
+        raise RuntimeError('lease expiry must include a timezone')
+    remaining = (parsed.astimezone(timezone.utc) - datetime.now(timezone.utc)).total_seconds()
+    if remaining <= 0:
+        raise RuntimeError('lease is already expired')
+    return remaining
+
+
+def _emit(value: Mapping[str, Any], seat: Any | None = None) -> None:
+    try:
+        sys.stdout.write(json.dumps(value, sort_keys=True, separators=(',', ':')) + '\n')
+        sys.stdout.flush()
+    except BrokenPipeError:
+        if seat is not None:
+            seat.mark_response_loss()
+        raise
+
+
+def _approval_request(request: Mapping[str, Any]) -> tuple[str, bytes, Mapping[str, Any], bytes]:
+    _require_keys(
+        request,
+        frozenset({'approval', 'capability_b64', 'command', 'proposal_b64', 'request_id'}),
+    )
+    request_id = _uuid_text(request['request_id'])
+    proposal_bytes = _decode_b64(request['proposal_b64'], 'proposal_b64')
+    capability = _decode_b64(request['capability_b64'], 'capability_b64', minimum=32)
+    approval = request['approval']
+    if not isinstance(approval, dict):
+        raise ValueError('approval must be an object')
+    return request_id, proposal_bytes, approval, capability
+
+
+def _serve(seat: Any) -> int:
+    _emit({'ok': True, 'type': 'handshake', **seat.handshake()}, seat)
+    for raw_line in sys.stdin:
+        if len(raw_line.encode('utf-8')) > _REQUEST_LIMIT:
+            seat.reject_protocol('request_too_large')
+            _emit({'ok': False, 'refusal_class': 'request_too_large', 'state': seat.state}, seat)
+            return 2
+        request_id: str | None = None
+        try:
+            request = _strict_json(raw_line)
+            command = request.get('command')
+            if command in {'execute_approved', 'observe'}:
+                request_id, proposal_bytes, approval, capability = _approval_request(request)
+                proposal = _strict_json(proposal_bytes.decode('utf-8'))
+                operation = proposal.get('op')
+                if command == 'observe' and operation not in {'observe', 'verify'}:
+                    raise ValueError('observe command requires a read proposal')
+                if command == 'execute_approved' and operation not in {'activate', 'focus'}:
+                    raise ValueError('execute_approved requires an action proposal')
+                result = seat.execute_approved(proposal_bytes, approval, capability)
+                _emit({
+                    'ok': True,
+                    'request_id': request_id,
+                    'result': result,
+                    'state': seat.state,
+                }, seat)
+                continue
+            if command == 'cancel':
+                _require_keys(request, frozenset({'command', 'request_id'}))
+                request_id = _uuid_text(request['request_id'])
+                result = seat.cancel()
+                _emit({'ok': True, 'request_id': request_id, 'result': result}, seat)
+                return 0
+            if command == 'close':
+                _require_keys(request, frozenset({'command', 'request_id'}))
+                request_id = _uuid_text(request['request_id'])
+                result = seat.close()
+                _emit({'ok': True, 'request_id': request_id, 'result': result})
+                return 0
+            raise ValueError('unknown command')
+        except ValueError:
+            if seat.state not in {'cancelled', 'failed', 'indeterminate', 'rejected', 'replayed', 'stale'}:
+                seat.reject_protocol('protocol_invalid')
+            _emit({
+                'ok': False,
+                'refusal_class': 'protocol_invalid',
+                'request_id': request_id,
+                'state': seat.state,
+            }, seat)
+            return 2
+        except Exception as exc:
+            refusal_class = getattr(exc, 'refusal_class', 'worker_failure')
+            _emit({
+                'ok': False,
+                'refusal_class': refusal_class,
+                'request_id': request_id,
+                'state': seat.state,
+            }, seat)
+            return 2
+    seat.mark_response_loss()
+    return 2
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.lock_wait_seconds < 0:
+        raise RuntimeError('lock wait must be nonnegative')
+    actual_commit = _current_commit()
+    if args.hands_commit != actual_commit:
+        raise RuntimeError('declared Hands commit does not match the running checkout')
+    lease_runtime = _lease_runtime_seconds(args.lease_expires_at)
+    secret_value = os.environ.pop(args.lease_secret_env, None)
+    if secret_value is None:
+        raise RuntimeError('lease secret environment variable is missing')
+    lease_secret = _decode_b64(secret_value, 'lease_secret', minimum=32)
+    _bind_display(args.display)
+
+    from consultation_v2.display_lock import display_lock_ttl, entrypoint_display_lock
+    from consultation_v2.supervised_ui_receipts import HandsReceiptStore
+    from consultation_v2.supervised_ui_seat import SupervisedUiSeat
+
+    hands_incarnation_id = str(uuid.uuid4())
+    public_roots = [str(REPO_ROOT.resolve(strict=True)), *args.public_repo_root]
+    resolved_public_roots = {str(Path(root).resolve(strict=True)) for root in public_roots}
+    if len(resolved_public_roots) < 2:
+        raise RuntimeError('Hands and at least one additional public repository root are required')
+    if any(not (Path(root) / '.git').exists() for root in resolved_public_roots):
+        raise RuntimeError('every public repository root must identify a Git checkout')
+    store = HandsReceiptStore.open_external(
+        args.receipt_root,
+        sorted(resolved_public_roots),
+        session_id=args.session_id,
+        presence_incarnation_id=args.presence_incarnation_id,
+        hands_incarnation_id=hands_incarnation_id,
+        hands_commit=actual_commit,
+    )
+    seat = None
+    try:
+        with entrypoint_display_lock(
+            display=args.display,
+            policy='discretionary',
+            request_id=args.session_id,
+            entrypoint='scripts/run_supervised_ui_seat.py',
+            payload={'seat_mode': 'supervised_ui'},
+            wait_seconds=args.lock_wait_seconds,
+            ttl=display_lock_ttl(lease_runtime),
+        ):
+            seat = SupervisedUiSeat(
+                platform=args.platform,
+                lease_secret=lease_secret,
+                lease_expires_at=args.lease_expires_at,
+                presence_incarnation_id=args.presence_incarnation_id,
+                hands_incarnation_id=hands_incarnation_id,
+                hands_commit=actual_commit,
+                receipt_store=store,
+            )
+            return _serve(seat)
+    finally:
+        if seat is not None and not seat.closed:
+            try:
+                seat.close()
+            except Exception:
+                store.close()
+        elif seat is None:
+            store.close()
+
+
+def _exit_on_signal(signum: int, _frame: Any) -> None:
+    raise SystemExit(128 + signum)
+
+
+if __name__ == '__main__':
+    signal.signal(signal.SIGTERM, _exit_on_signal)
+    signal.signal(signal.SIGINT, _exit_on_signal)
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

Implements the reviewed supervised UI seat pinned to `palios-taey/palios-training@58b108042e66fa508765a6277c033cc5a8f86abd`.

- exposes a strict, policy-filtered public UI projection with lease-scoped opaque refs and revisions
- binds one-use approval to the exact proposal digest, ref, revision, operation, effect, incarnation, and expiry
- durably records proposal, approval spend, execution, observation, and verification transitions outside the public repository
- re-observes immediately before execution and permits one exact AT-SPI primitive with no coordinate fallback
- requires a fresh, separately approved verification turn after action
- ships initial platform policies that grant only local `focus`

## Why

The first supervised seat needs to let Taey choose the referenced object, operation, and next turn while keeping every real UI effect proposal-bound, one-use, auditable, and fail-closed. Supervisor-authored sequences, implicit loops, reconstructed events, and unapproved outward effects remain outside the contract.

## Impact

This is a new security-sensitive surface: 302 new/touched symbols and 16 new execution flows were identified by staged GitNexus analysis. Legacy blast radius is isolated, but independent r5/adversarial review is required before merge or deployment.

## Verification

- Python compilation completed cleanly for all new and changed modules
- Ruff completed cleanly
- consultation-v2 contract, platform-independence, no-silent-fallback, exact-match, and stay-clean gates completed cleanly
- static scans found no operator paths, private IPs, coordinate fallbacks, shell execution, or outward-action primitives in the changed public code
- production startup observation at this exact commit acquired the configured real-display lock, emitted the strict `supervised_ui_v1` handshake, accepted only `close`, and exited 0

No UI observation/action/model request was performed in the production check, and no SFT pair is claimed. Private receipts remain outside Git and are available to CONTROL reviewers through the established private handoff.